### PR TITLE
feat: app 레이아웃 전체 페이지에 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,16 @@ import { GlobalResetStyle } from '@/styles/reset';
 import { GlobalTypographyStyle } from '@/styles/typography';
 import { theme } from './styles/theme';
 import Router from '@/routes/router';
+import AppLayout from '@/components/layout/AppLayout';
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <Global styles={GlobalResetStyle} />
       <Global styles={GlobalTypographyStyle} />
-      <Router />
+      <AppLayout>
+        <Router />
+      </AppLayout>
     </ThemeProvider>
   );
 }

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+type AppLayoutProps = {
+  children: React.ReactNode;
+};
+
+const AppLayout = ({ children }: AppLayoutProps) => {
+  return (
+    <Background>
+      <Container>{children}</Container>
+    </Background>
+  );
+};
+
+export default AppLayout;
+
+const Background = styled.div`
+  width: 100%;
+  min-height: 100vh;
+`;
+
+const Container = styled.div`
+  max-width: 720px;
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 0;
+`;


### PR DESCRIPTION
## ✨ 요약

> PR의 목적을 한두 문장으로 요약합니다.

페이지 구현 전 모든 페이지에 적용되어야 하는 레이아웃을 구현하였습니다. 

## 🔗 작업 내용

- [x] width 720px로 레이아웃 구현 후 페이지에 적용

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

컴포넌트 폴더에 app layout 컴포넌트 생성 후 app 컴포넌트에 적용하여 모든 페이지에 레이아웃이 적용될 수 있도록 하였습니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #3 
