### PR TITLE
feat: 헤더, 하단 네비게이션 바 구현

### DIFF
--- a/src/assets/logo.svg
+++ b/src/assets/logo.svg
@@ -1,0 +1,6 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.75 15H26.25" stroke="#FF685E" stroke-width="3.75" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 26.25V3.75" stroke="#FF685E" stroke-width="3.75" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.375 9.375L20.625 20.625" stroke="#FF685E" stroke-width="3.75" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.375 20.625L20.625 9.375" stroke="#FF685E" stroke-width="3.75" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled';
+import logo from '@/assets/logo.svg';
+
+type HeaderProps = {
+  title?: string;
+};
+
+const Header = ({ title = '' }: HeaderProps) => {
+  return (
+    <Container>
+      <Logo src={logo} alt='로고' />
+      <Title>{title}</Title>
+      <div></div>
+    </Container>
+  );
+};
+
+export default Header;
+
+const Container = styled.header`
+  width: 100%;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 ${({ theme }) => theme.spacing[3]};
+`;
+
+const Logo = styled.img`
+  width: 30px;
+  height: 30px;
+`;
+
+const Title = styled.h1`
+  font-size: ${({ theme }) => theme.typography.title1.fontSize};
+  line-height: ${({ theme }) => theme.typography.title1.lineHeight};
+  font-weight: ${({ theme }) => theme.typography.fontWeight.bold};
+  color: ${({ theme }) => theme.colors.text.default};
+`;

--- a/src/components/layout/NavigationCustomer.tsx
+++ b/src/components/layout/NavigationCustomer.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+import NavigationItem from './NavigationItem';
+import { CircleUserRound, House, Mails, MapPin } from 'lucide-react';
+import { ROUTE_PATH } from '@/routes/paths';
+
+const NavigationCustomer = () => {
+  return (
+    <Nav>
+      <NavigationItem to={ROUTE_PATH.HOME} icon={<House />} name='대시보드' />
+      <NavigationItem to={ROUTE_PATH.MAP} icon={<MapPin />} name='지도' />
+      <NavigationItem to={ROUTE_PATH.LETTER} icon={<Mails />} name='편지쓰기' />
+      <NavigationItem
+        to={ROUTE_PATH.MY_PAGE}
+        icon={<CircleUserRound />}
+        name='설정'
+      />
+    </Nav>
+  );
+};
+
+export default NavigationCustomer;
+
+const Nav = styled.nav`
+  position: absolute;
+  bottom: 0;
+  z-index: 1;
+  width: 100%;
+  max-width: 720px;
+  height: 70px;
+  padding: 0 ${({ theme }) => theme.spacing[10]};
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  ul {
+    display: flex;
+    gap: 20px;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+`;

--- a/src/components/layout/NavigationCustomer.tsx
+++ b/src/components/layout/NavigationCustomer.tsx
@@ -2,17 +2,40 @@ import styled from '@emotion/styled';
 import NavigationItem from './NavigationItem';
 import { CircleUserRound, House, Mails, MapPin } from 'lucide-react';
 import { ROUTE_PATH } from '@/routes/paths';
+import { useLocation } from 'react-router';
 
 const NavigationCustomer = () => {
+  const { pathname } = useLocation();
+
   return (
     <Nav>
-      <NavigationItem to={ROUTE_PATH.HOME} icon={<House />} name='대시보드' />
-      <NavigationItem to={ROUTE_PATH.MAP} icon={<MapPin />} name='지도' />
-      <NavigationItem to={ROUTE_PATH.LETTER} icon={<Mails />} name='편지쓰기' />
+      <NavigationItem
+        to={ROUTE_PATH.HOME}
+        icon={<House />}
+        name='대시보드'
+        type='customer'
+        active={pathname === ROUTE_PATH.HOME}
+      />
+      <NavigationItem
+        to={ROUTE_PATH.MAP}
+        icon={<MapPin />}
+        name='지도'
+        type='customer'
+        active={pathname === ROUTE_PATH.MAP}
+      />
+      <NavigationItem
+        to={ROUTE_PATH.LETTER}
+        icon={<Mails />}
+        name='편지쓰기'
+        type='customer'
+        active={pathname === ROUTE_PATH.LETTER}
+      />
       <NavigationItem
         to={ROUTE_PATH.MY_PAGE}
         icon={<CircleUserRound />}
         name='설정'
+        type='customer'
+        active={pathname === ROUTE_PATH.MY_PAGE}
       />
     </Nav>
   );
@@ -32,12 +55,4 @@ const Nav = styled.nav`
   display: flex;
   align-items: center;
   justify-content: space-between;
-
-  ul {
-    display: flex;
-    gap: 20px;
-    list-style: none;
-    padding: 0;
-    margin: 0;
-  }
 `;

--- a/src/components/layout/NavigationItem.tsx
+++ b/src/components/layout/NavigationItem.tsx
@@ -5,33 +5,50 @@ type NavigationItemProps = {
   to: string;
   icon: React.ReactNode;
   name: string;
+  type: 'customer' | 'owner';
+  active: boolean;
 };
 
-const NavigationItem = ({ to, icon, name }: NavigationItemProps) => {
+const NavigationItem = ({
+  to,
+  icon,
+  name,
+  type,
+  active,
+}: NavigationItemProps) => {
   return (
-    <Container to={to}>
+    <Container to={to} active={active} type={type}>
       {icon}
-      <Title>{name}</Title>
+      <Title active={active} type={type}>
+        {name}
+      </Title>
     </Container>
   );
 };
 
 export default NavigationItem;
 
-const Container = styled(Link)`
+const Container = styled(Link)<{ active: boolean; type: 'customer' | 'owner' }>`
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   width: 100%;
+
+  ${({ active, theme, type }) =>
+    active &&
+    `
+    color: ${type === 'customer' ? theme.colors.customer.main : theme.colors.owner.main};
+  `}
   max-width: 720px;
   height: 70px;
   gap: ${({ theme }) => theme.spacing[2]};
 `;
 
-const Title = styled.p`
+const Title = styled.p<{ active: boolean; type: 'customer' | 'owner' }>`
   font-size: ${({ theme }) => theme.typography.body2.fontSize};
   line-height: ${({ theme }) => theme.typography.body2.lineHeight};
   font-weight: ${({ theme }) => theme.typography.fontWeight.medium};
-  color: ${({ theme }) => theme.colors.text.default};
+  color: ${({ active, theme, type }) =>
+    active ? theme.colors[type].main : theme.colors.text.default};
 `;

--- a/src/components/layout/NavigationItem.tsx
+++ b/src/components/layout/NavigationItem.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import { Link } from 'react-router';
+
+type NavigationItemProps = {
+  to: string;
+  icon: React.ReactNode;
+  name: string;
+};
+
+const NavigationItem = ({ to, icon, name }: NavigationItemProps) => {
+  return (
+    <Container to={to}>
+      {icon}
+      <Title>{name}</Title>
+    </Container>
+  );
+};
+
+export default NavigationItem;
+
+const Container = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 720px;
+  height: 70px;
+  gap: ${({ theme }) => theme.spacing[2]};
+`;
+
+const Title = styled.p`
+  font-size: ${({ theme }) => theme.typography.body2.fontSize};
+  line-height: ${({ theme }) => theme.typography.body2.lineHeight};
+  font-weight: ${({ theme }) => theme.typography.fontWeight.medium};
+  color: ${({ theme }) => theme.colors.text.default};
+`;

--- a/src/components/layout/NavigationOwner.tsx
+++ b/src/components/layout/NavigationOwner.tsx
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+import NavigationItem from './NavigationItem';
+import { CircleUserRound, Handshake, House, MapPin } from 'lucide-react';
+import { ROUTE_PATH } from '@/routes/paths';
+
+const NavigationOwner = () => {
+  return (
+    <Nav>
+      <NavigationItem to={ROUTE_PATH.HOME} icon={<House />} name='대시보드' />
+      <NavigationItem
+        to={ROUTE_PATH.FEEDBACK}
+        icon={<MapPin />}
+        name='피드백'
+      />
+      <NavigationItem
+        to={ROUTE_PATH.INTERACTION}
+        icon={<Handshake />}
+        name='고객소통'
+      />
+      <NavigationItem
+        to={ROUTE_PATH.MY_PAGE}
+        icon={<CircleUserRound />}
+        name='설정'
+      />
+    </Nav>
+  );
+};
+
+export default NavigationOwner;
+
+const Nav = styled.nav`
+  position: absolute;
+  bottom: 0;
+  z-index: 1;
+  width: 100%;
+  max-width: 720px;
+  height: 70px;
+  padding: 0 ${({ theme }) => theme.spacing[10]};
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  ul {
+    display: flex;
+    gap: 20px;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+`;

--- a/src/components/layout/NavigationOwner.tsx
+++ b/src/components/layout/NavigationOwner.tsx
@@ -2,25 +2,40 @@ import styled from '@emotion/styled';
 import NavigationItem from './NavigationItem';
 import { CircleUserRound, Handshake, House, MapPin } from 'lucide-react';
 import { ROUTE_PATH } from '@/routes/paths';
+import { useLocation } from 'react-router';
 
 const NavigationOwner = () => {
+  const { pathname } = useLocation();
+
   return (
     <Nav>
-      <NavigationItem to={ROUTE_PATH.HOME} icon={<House />} name='대시보드' />
+      <NavigationItem
+        to={ROUTE_PATH.HOME}
+        icon={<House />}
+        name='대시보드'
+        type='owner'
+        active={pathname === ROUTE_PATH.HOME}
+      />
       <NavigationItem
         to={ROUTE_PATH.FEEDBACK}
         icon={<MapPin />}
         name='피드백'
+        type='owner'
+        active={pathname === ROUTE_PATH.FEEDBACK}
       />
       <NavigationItem
         to={ROUTE_PATH.INTERACTION}
         icon={<Handshake />}
         name='고객소통'
+        type='owner'
+        active={pathname === ROUTE_PATH.INTERACTION}
       />
       <NavigationItem
         to={ROUTE_PATH.MY_PAGE}
         icon={<CircleUserRound />}
         name='설정'
+        type='owner'
+        active={pathname === ROUTE_PATH.MY_PAGE}
       />
     </Nav>
   );

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,5 +1,12 @@
+import Header from '@/components/layout/Header';
+
 const MainPage = () => {
-  return <div>main page</div>;
+  return (
+    <>
+      <Header />
+      <div>main page</div>
+    </>
+  );
 };
 
 export default MainPage;

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,10 +1,12 @@
 import Header from '@/components/layout/Header';
+import NavigationBar from '@/components/layout/NavigationCustomer';
 
 const MainPage = () => {
   return (
     <>
       <Header />
       <div>main page</div>
+      <NavigationBar />
     </>
   );
 };

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -2,5 +2,11 @@ export const ROUTE_PATH = {
   HOME: '/',
   LANDING: '/landing',
   LOGIN: '/login',
+  MY_PAGE: '/my',
+
   MAP: '/map',
+  LETTER: '/letter',
+
+  FEEDBACK: '/feedback',
+  INTERACTION: '/interaction',
 };


### PR DESCRIPTION
## ✨ 요약

> PR의 목적을 한두 문장으로 요약합니다.

로그인 이후 모든 페이지에서 사용될 헤더, 하단 네비게이션바를 구현합니다. 

## 🔗 작업 내용

- [x] header 구현
- [x] navigation 구현

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

header는 title을 string으로 입력 받을 수 있도록 구현하였습니다. 
하단 네비게이션 바는 customer, owner에 따라 다른 색상으로 표시하였습니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

상단 로고 이미지는 추후 변경이 필요합니다. 

## 📸 스크린샷 (Screenshots)

<img width="1348" height="194" alt="image" src="https://github.com/user-attachments/assets/964a095f-17cb-402f-8c7b-2a7357416e77" />

<img width="1166" height="167" alt="image" src="https://github.com/user-attachments/assets/11e0ebd0-f2a8-4160-8645-ded66dadc048" />

## 🔗 관련 이슈

- Close #10 
