### PR TITLE
feat: 쿠폰 페이지 구현

### DIFF
--- a/src/components/layout/NavigationCustomer.tsx
+++ b/src/components/layout/NavigationCustomer.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import NavigationItem from './NavigationItem';
-import { CircleUserRound, House, Mails, MapPin } from 'lucide-react';
+import { CircleUserRound, House, MapPin, Ticket } from 'lucide-react';
 import { ROUTE_PATH } from '@/routes/paths';
 import { useLocation } from 'react-router-dom';
 import { NAV_HEIGHT } from '@/constants/number';
@@ -25,11 +25,11 @@ const NavigationCustomer = () => {
         active={pathname === ROUTE_PATH.MAP}
       />
       <NavigationItem
-        to={ROUTE_PATH.LETTER}
-        icon={<Mails />}
-        name='편지쓰기'
+        to={ROUTE_PATH.COUPON}
+        icon={<Ticket />}
+        name='쿠폰 교환'
         type='customer'
-        active={pathname === ROUTE_PATH.LETTER}
+        active={pathname === ROUTE_PATH.COUPON}
       />
       <NavigationItem
         to={ROUTE_PATH.MY_PAGE}

--- a/src/pages/coupon/CouponPage.tsx
+++ b/src/pages/coupon/CouponPage.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import Header from '@/components/layout/Header';
+import { HEADER_HEIGHT, NAV_HEIGHT } from '@/constants/number';
+import NavigationCustomer from '@/components/layout/NavigationCustomer';
+import MyPointSection from './components/MyPointSection';
+import ExchangeCouponSection from './components/ExchangeCouponSection';
+import { useState } from 'react';
+
+const CouponPage = () => {
+  const [point, setPoint] = useState<number>(1250);
+  return (
+    <>
+      <Header title='쿠폰 교환하기' />
+      <Main>
+        <MyPointSection point={point} />
+        <ExchangeCouponSection point={point} updatePoint={setPoint} />
+      </Main>
+      <NavigationCustomer />
+    </>
+  );
+};
+
+export default CouponPage;
+
+const Main = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  min-height: calc(100dvh - ${HEADER_HEIGHT}px - ${NAV_HEIGHT}px);
+  background-color: ${({ theme }) => theme.colors.customer.background};
+`;

--- a/src/pages/coupon/components/ExchangeCouponItem.tsx
+++ b/src/pages/coupon/components/ExchangeCouponItem.tsx
@@ -1,0 +1,81 @@
+import Typography from '@/components/UI/Typography';
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+
+type ExchangeCouponItemProps = {
+  title: string;
+  description: string;
+  price: number;
+  point: number;
+  updatePoint: (point: number) => void;
+};
+
+const ExchangeCouponItem = ({
+  title,
+  description,
+  price,
+  point,
+  updatePoint,
+}: ExchangeCouponItemProps) => {
+  const theme = useTheme();
+
+  return (
+    <Container>
+      <Typography variant='subtitle1' weight='bold'>
+        {title}
+      </Typography>
+      <DescriptionBox>
+        <Typography variant='body2'>{description}</Typography>
+      </DescriptionBox>
+      <ImageDiv />
+      <PriceBox>
+        <Typography variant='subtitle1' weight='medium'>
+          {price}p
+        </Typography>
+        <Button
+          disabled={point < price}
+          onClick={() => updatePoint(point - price)}
+        >
+          <Typography variant='body2' color={theme.colors.gray[0]}>
+            교환하기
+          </Typography>
+        </Button>
+      </PriceBox>
+    </Container>
+  );
+};
+
+export default ExchangeCouponItem;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: ${({ theme }) => theme.spacing[4]};
+  background-color: ${({ theme }) => theme.colors.gray[0]};
+  gap: ${({ theme }) => theme.spacing[1]};
+`;
+
+const DescriptionBox = styled.div`
+  flex-grow: 1;
+`;
+
+const ImageDiv = styled.div`
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  background-color: ${({ theme }) => theme.colors.gray[20]};
+`;
+
+const PriceBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: ${({ theme }) => theme.spacing[1]};
+`;
+
+const Button = styled.button<{ disabled: boolean }>`
+  background-color: ${({ theme, disabled }) =>
+    disabled ? theme.colors.customer.disabled : theme.colors.customer.main};
+  border-radius: 12px;
+  padding: ${({ theme }) => theme.spacing[2]} ${({ theme }) => theme.spacing[4]};
+  cursor: pointer;
+`;

--- a/src/pages/coupon/components/ExchangeCouponSection.tsx
+++ b/src/pages/coupon/components/ExchangeCouponSection.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import ExchangeCouponItem from './ExchangeCouponItem';
+import { exchangeCoupon } from '../constants/coupon';
+
+type ExchangeCouponSectionProps = {
+  point: number;
+  updatePoint: (point: number) => void;
+};
+
+const ExchangeCouponSection = ({
+  point,
+  updatePoint,
+}: ExchangeCouponSectionProps) => {
+  return (
+    <Container>
+      {exchangeCoupon.map((coupon) => (
+        <ExchangeCouponItem
+          key={coupon.id}
+          {...coupon}
+          point={point}
+          updatePoint={updatePoint}
+        />
+      ))}
+    </Container>
+  );
+};
+
+export default ExchangeCouponSection;
+
+const Container = styled.section`
+  width: 100%;
+  max-width: 600px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: ${({ theme }) => theme.spacing[2]};
+  padding: ${({ theme }) => theme.spacing[6]};
+`;

--- a/src/pages/coupon/components/MyPointSection.tsx
+++ b/src/pages/coupon/components/MyPointSection.tsx
@@ -1,0 +1,29 @@
+import Typography from '@/components/UI/Typography';
+import styled from '@emotion/styled';
+
+type MyPointSectionProps = {
+  point: number;
+};
+
+const MyPointSection = ({ point }: MyPointSectionProps) => {
+  return (
+    <Container>
+      <Typography variant='title2' weight='bold' as='h2'>
+        보유 포인트: {point}p
+      </Typography>
+    </Container>
+  );
+};
+
+export default MyPointSection;
+
+const Container = styled.section`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${({ theme }) => `${theme.spacing[4]} ${theme.spacing[6]}`};
+  background-color: ${({ theme }) => theme.colors.gray[0]};
+  border-top: 1px solid ${({ theme }) => theme.colors.gray[50]};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray[50]};
+`;

--- a/src/pages/coupon/constants/coupon.ts
+++ b/src/pages/coupon/constants/coupon.ts
@@ -1,0 +1,38 @@
+export const exchangeCoupon = [
+  {
+    id: 1,
+    title: '초밥집',
+    description: '모둠초밥A 10% 할인',
+    price: 1200,
+  },
+  {
+    id: 2,
+    title: '달콤카페',
+    description: '아메리카노 쿠폰',
+    price: 1800,
+  },
+  {
+    id: 3,
+    title: '초밥집',
+    description: '모둠초밥B 10% 할인',
+    price: 2000,
+  },
+  {
+    id: 4,
+    title: '달콤카페',
+    description: '아이스 아메리카노 + 디저트 세트',
+    price: 4200,
+  },
+  {
+    id: 5,
+    title: '초밥집',
+    description: '미니우동 쿠폰',
+    price: 1800,
+  },
+  {
+    id: 6,
+    title: '달콤카페',
+    description: '음료 사이즈업',
+    price: 500,
+  },
+] as const;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -6,11 +6,11 @@ import LoginPage from '@/pages/login/LoginPage';
 import MapPage from '@/pages/map/MapPage';
 import SearchPage from '@/pages/search/SearchPage';
 import StoreDetailPage from '@/pages/store/StoreDetailPage';
-
 import LetterPage from '@/pages/letter/LetterPage';
 import MyPage from '@/pages/my/MyPage';
 import MyCouponPage from '@/pages/my/coupon/MyCouponPage';
 import MyLetterPage from '@/pages/my/letter/MyLetterPage';
+import CouponPage from '@/pages/coupon/CouponPage';
 
 const Router = () => {
   return (
@@ -21,8 +21,8 @@ const Router = () => {
       <Route path={ROUTE_PATH.MAP} element={<MapPage />} />
       <Route path={ROUTE_PATH.SEARCH} element={<SearchPage />} />
       <Route path={ROUTE_PATH.STORE_DETAIL} element={<StoreDetailPage />} />
-
       <Route path={ROUTE_PATH.LETTER} element={<LetterPage />} />
+      <Route path={ROUTE_PATH.COUPON} element={<CouponPage />} />
       <Route path={ROUTE_PATH.MY_PAGE} element={<MyPage />}>
         <Route path={ROUTE_PATH.MY_COUPON} element={<MyCouponPage />} />
         <Route path={ROUTE_PATH.MY_LETTER} element={<MyLetterPage />} />


### PR DESCRIPTION
## ✨ 요약

> PR의 목적을 한두 문장으로 요약합니다.

쿠폰 페이지를 구현하였습니다. 

## 🔗 작업 내용

- [x] 쿠폰 페이지 구현
- [x] 하단 네비게이션 편지 쓰기 탭을 쿠폰 교환 탭으로 변경

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

쿠폰 페이지의 쿠폰을 grid로 2열로 배치하였습니다. 
하단 네비게이션 바의 편지쓰기를 쿠폰 교환탭으로 변경하였습니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)
<img width="278" height="600" alt="image" src="https://github.com/user-attachments/assets/3a2f6f32-2dba-4a0f-ba50-e54a0bdd4c18" />


## 🔗 관련 이슈

- Close #21 
