### PR TITLE
feat: 피드백 관리 페이지 구현

### DIFF
--- a/src/pages/feedback/FeedbackPage.tsx
+++ b/src/pages/feedback/FeedbackPage.tsx
@@ -8,13 +8,24 @@ import { feedbackData } from './mocks/feedback';
 
 const FeedbackPage = () => {
   const location = useLocation();
+  const pendingList = feedbackData.filter(
+    (feedback) => feedback.status === 'PROCESSING',
+  );
+  const completedList = feedbackData.filter(
+    (feedback) => feedback.status === 'DONE',
+  );
 
   return (
     <>
       <Header title='피드백 관리' />
       <Main>
-        <TabNavigation selected={location.pathname} />
-        <Outlet context={{ feedbackData }} />
+        <TabNavigation
+          selected={location.pathname}
+          allCount={feedbackData.length}
+          pendingCount={pendingList.length}
+          completedCount={completedList.length}
+        />
+        <Outlet context={{ feedbackData, pendingList, completedList }} />
       </Main>
       <NavigationOwner />
     </>

--- a/src/pages/feedback/FeedbackPage.tsx
+++ b/src/pages/feedback/FeedbackPage.tsx
@@ -1,0 +1,28 @@
+import Header from '@/components/layout/Header';
+import NavigationOwner from '@/components/layout/NavigationOwner';
+import { HEADER_HEIGHT, NAV_HEIGHT } from '@/constants/number';
+import styled from '@emotion/styled';
+import TabNavigation from './components/TabNavigation';
+import { Outlet, useLocation } from 'react-router-dom';
+
+const FeedbackPage = () => {
+  const location = useLocation();
+
+  return (
+    <>
+      <Header title='피드백 관리' />
+      <Main>
+        <TabNavigation selected={location.pathname} />
+        <Outlet />
+      </Main>
+      <NavigationOwner />
+    </>
+  );
+};
+
+export default FeedbackPage;
+const Main = styled.main`
+  height: 100%;
+  min-height: calc(100dvh - ${HEADER_HEIGHT}px - ${NAV_HEIGHT}px);
+  background-color: ${({ theme }) => theme.colors.owner.background};
+`;

--- a/src/pages/feedback/FeedbackPage.tsx
+++ b/src/pages/feedback/FeedbackPage.tsx
@@ -4,6 +4,7 @@ import { HEADER_HEIGHT, NAV_HEIGHT } from '@/constants/number';
 import styled from '@emotion/styled';
 import TabNavigation from './components/TabNavigation';
 import { Outlet, useLocation } from 'react-router-dom';
+import { feedbackData } from './mocks/feedback';
 
 const FeedbackPage = () => {
   const location = useLocation();
@@ -13,7 +14,7 @@ const FeedbackPage = () => {
       <Header title='피드백 관리' />
       <Main>
         <TabNavigation selected={location.pathname} />
-        <Outlet />
+        <Outlet context={{ feedbackData }} />
       </Main>
       <NavigationOwner />
     </>

--- a/src/pages/feedback/components/AllTab.tsx
+++ b/src/pages/feedback/components/AllTab.tsx
@@ -1,0 +1,5 @@
+const AllTab = () => {
+  return <div>All Feedback</div>;
+};
+
+export default AllTab;

--- a/src/pages/feedback/components/AllTab.tsx
+++ b/src/pages/feedback/components/AllTab.tsx
@@ -1,5 +1,34 @@
+import { useOutletContext } from 'react-router-dom';
+import type { FeedbackData } from '../mocks/feedback';
+import FeedbackItem from './FeedbackItem';
+import styled from '@emotion/styled';
+
 const AllTab = () => {
-  return <div>All Feedback</div>;
+  const { feedbackData } = useOutletContext<{ feedbackData: FeedbackData[] }>();
+
+  return (
+    <Container>
+      {feedbackData.map((feedback) => (
+        <FeedbackItem
+          key={feedback.id}
+          satisfaction={feedback.rating}
+          tag={feedback.type}
+          createAt={feedback.createdAt}
+          content={feedback.modifiedContent}
+          reply={feedback.reply}
+          status={feedback.status}
+        />
+      ))}
+    </Container>
+  );
 };
 
 export default AllTab;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: ${({ theme }) => `${theme.spacing[2]} ${theme.spacing[6]}`};
+  gap: ${({ theme }) => theme.spacing[4]};
+`;

--- a/src/pages/feedback/components/CompletedTab.tsx
+++ b/src/pages/feedback/components/CompletedTab.tsx
@@ -1,5 +1,37 @@
+import { useOutletContext } from 'react-router-dom';
+import type { FeedbackData } from '../mocks/feedback';
+import FeedbackItem from './FeedbackItem';
+import styled from '@emotion/styled';
+
 const CompletedTab = () => {
-  return <div>Completed Feedback</div>;
+  const { feedbackData } = useOutletContext<{ feedbackData: FeedbackData[] }>();
+  const completedList = feedbackData.filter(
+    (feedback) => feedback.status === 'DONE',
+  );
+
+  return (
+    <Container>
+      {completedList.map((feedback) => (
+        <FeedbackItem
+          key={feedback.id}
+          satisfaction={feedback.rating}
+          tag={feedback.type}
+          createAt={feedback.createdAt}
+          content={feedback.modifiedContent}
+          reply={feedback.reply}
+          status={feedback.status}
+        />
+      ))}
+    </Container>
+  );
 };
 
 export default CompletedTab;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: ${({ theme }) => `${theme.spacing[2]} ${theme.spacing[6]}`};
+  gap: ${({ theme }) => theme.spacing[4]};
+`;

--- a/src/pages/feedback/components/CompletedTab.tsx
+++ b/src/pages/feedback/components/CompletedTab.tsx
@@ -1,0 +1,5 @@
+const CompletedTab = () => {
+  return <div>Completed Feedback</div>;
+};
+
+export default CompletedTab;

--- a/src/pages/feedback/components/CompletedTab.tsx
+++ b/src/pages/feedback/components/CompletedTab.tsx
@@ -4,10 +4,9 @@ import FeedbackItem from './FeedbackItem';
 import styled from '@emotion/styled';
 
 const CompletedTab = () => {
-  const { feedbackData } = useOutletContext<{ feedbackData: FeedbackData[] }>();
-  const completedList = feedbackData.filter(
-    (feedback) => feedback.status === 'DONE',
-  );
+  const { completedList } = useOutletContext<{
+    completedList: FeedbackData[];
+  }>();
 
   return (
     <Container>

--- a/src/pages/feedback/components/FeedbackItem.tsx
+++ b/src/pages/feedback/components/FeedbackItem.tsx
@@ -2,7 +2,7 @@ import Typography from '@/components/UI/Typography';
 import { LetterTag, type LetterTagType } from '@/constants/letter';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { Bot, Star, Store } from 'lucide-react';
+import { Bot, Heart, Star, Store } from 'lucide-react';
 
 type PendingItemProps = {
   satisfaction: number;
@@ -62,15 +62,27 @@ const FeedbackItem = ({
           <Typography variant='body1'>{reply}</Typography>
         </Card>
       ) : (
-        <Card status='PROCESSING'>
+        <>
+          <Card status='PROCESSING'>
+            <Wrapper>
+              <Bot />
+              <Typography variant='body1' weight='medium'>
+                AI 추천 개선 방안
+              </Typography>
+            </Wrapper>
+            <Typography variant='body1'>~~~ 이렇게 개선해보세요</Typography>
+          </Card>
           <Wrapper>
-            <Bot />
-            <Typography variant='body1' weight='medium'>
-              AI 추천 개선 방안
-            </Typography>
+            <LinkButton>
+              <Typography variant='body2' weight='medium' color='white'>
+                답변하기
+              </Typography>
+            </LinkButton>
+            <HeartButton type='button'>
+              <Heart size={20} />
+            </HeartButton>
           </Wrapper>
-          <Typography variant='body1'>~~~ 이렇게 개선해보세요</Typography>
-        </Card>
+        </>
       )}
     </Card>
   );
@@ -123,4 +135,25 @@ const StatusBox = styled.div<{ status: 'PROCESSING' | 'DONE' }>`
   padding: ${({ theme }) => theme.spacing[1]} ${({ theme }) => theme.spacing[2]};
   border-radius: 16px;
   background-color: ${({ theme, status }) => theme.colors.feedback[status]};
+`;
+
+const LinkButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-grow: 1;
+  align-items: center;
+  padding: ${({ theme }) => theme.spacing[2]} ${({ theme }) => theme.spacing[4]};
+  border-radius: 12px;
+  background-color: ${({ theme }) => theme.colors.owner.main};
+`;
+
+const HeartButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${({ theme }) => theme.spacing[2]};
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => theme.colors.gray[70]};
+  cursor: pointer;
 `;

--- a/src/pages/feedback/components/FeedbackItem.tsx
+++ b/src/pages/feedback/components/FeedbackItem.tsx
@@ -1,0 +1,126 @@
+import Typography from '@/components/UI/Typography';
+import { LetterTag, type LetterTagType } from '@/constants/letter';
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+import { Bot, Star, Store } from 'lucide-react';
+
+type PendingItemProps = {
+  satisfaction: number;
+  tag: LetterTagType;
+  createAt: string;
+  content: string;
+  reply: string | null;
+  status: 'PROCESSING' | 'DONE';
+};
+
+const FeedbackItem = ({
+  satisfaction,
+  tag,
+  createAt,
+  content,
+  reply,
+  status,
+}: PendingItemProps) => {
+  const theme = useTheme();
+
+  return (
+    <Card>
+      <LineWrapper>
+        <Wrapper>
+          <StarBox>
+            {[1, 2, 3, 4, 5].map((num) => (
+              <Star
+                key={num}
+                fill={num <= satisfaction ? 'gold' : 'none'}
+                stroke={theme.colors.gray[50]}
+                strokeWidth={num <= satisfaction ? 0 : 1}
+              />
+            ))}
+          </StarBox>
+          <TagBox tag={tag}>
+            <Typography variant='body2'>
+              {LetterTag.find((item) => item.value === tag)?.label}
+            </Typography>
+          </TagBox>
+          <StatusBox status={status}>
+            <Typography variant='body2'>
+              {status === 'PROCESSING' ? '처리 중' : '완료'}
+            </Typography>
+          </StatusBox>
+        </Wrapper>
+        <Typography variant='body2'>{createAt}</Typography>
+      </LineWrapper>
+      <Typography variant='body1'>{content}</Typography>
+      {reply ? (
+        <Card status='DONE'>
+          <Wrapper>
+            <Store />
+            <Typography variant='body1' weight='medium'>
+              사장님 답변
+            </Typography>
+          </Wrapper>
+          <Typography variant='body1'>{reply}</Typography>
+        </Card>
+      ) : (
+        <Card status='PROCESSING'>
+          <Wrapper>
+            <Bot />
+            <Typography variant='body1' weight='medium'>
+              AI 추천 개선 방안
+            </Typography>
+          </Wrapper>
+          <Typography variant='body1'>~~~ 이렇게 개선해보세요</Typography>
+        </Card>
+      )}
+    </Card>
+  );
+};
+
+export default FeedbackItem;
+
+const Card = styled.div<{ status?: 'PROCESSING' | 'DONE' }>`
+  display: flex;
+  flex-direction: column;
+  background-color: ${({ theme, status }) =>
+    status && status in theme.colors.feedback
+      ? theme.colors.feedback[status]
+      : theme.colors.gray[0]};
+  border-radius: 16px;
+  gap: ${({ theme }) => theme.spacing[3]};
+  padding: ${({ theme }) => `${theme.spacing[4]} ${theme.spacing[6]}`};
+  width: 100%;
+  max-width: 550px;
+`;
+
+const LineWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing[2]};
+`;
+
+const StarBox = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const TagBox = styled.div<{ tag: LetterTagType }>`
+  display: flex;
+  align-items: center;
+  padding: ${({ theme }) => theme.spacing[1]} ${({ theme }) => theme.spacing[2]};
+  border-radius: 16px;
+  background-color: ${({ theme, tag }) => theme.colors.tag[tag]};
+`;
+
+const StatusBox = styled.div<{ status: 'PROCESSING' | 'DONE' }>`
+  display: flex;
+  align-items: center;
+  padding: ${({ theme }) => theme.spacing[1]} ${({ theme }) => theme.spacing[2]};
+  border-radius: 16px;
+  background-color: ${({ theme, status }) => theme.colors.feedback[status]};
+`;

--- a/src/pages/feedback/components/FeedbackItem.tsx
+++ b/src/pages/feedback/components/FeedbackItem.tsx
@@ -31,6 +31,7 @@ const FeedbackItem = ({
             {[1, 2, 3, 4, 5].map((num) => (
               <Star
                 key={num}
+                size={20}
                 fill={num <= satisfaction ? 'gold' : 'none'}
                 stroke={theme.colors.gray[50]}
                 strokeWidth={num <= satisfaction ? 0 : 1}
@@ -50,7 +51,9 @@ const FeedbackItem = ({
         </Wrapper>
         <Typography variant='body2'>{createAt}</Typography>
       </LineWrapper>
-      <Typography variant='body1'>{content}</Typography>
+      <ContentBox>
+        <Typography variant='body1'>{content}</Typography>
+      </ContentBox>
       {reply ? (
         <Card status='DONE'>
           <Wrapper>
@@ -99,7 +102,7 @@ const Card = styled.div<{ status?: 'PROCESSING' | 'DONE' }>`
       : theme.colors.gray[0]};
   border-radius: 16px;
   gap: ${({ theme }) => theme.spacing[3]};
-  padding: ${({ theme }) => `${theme.spacing[4]} ${theme.spacing[6]}`};
+  padding: ${({ theme }) => `${theme.spacing[4]} ${theme.spacing[5]}`};
   width: 100%;
   max-width: 550px;
 `;
@@ -135,6 +138,10 @@ const StatusBox = styled.div<{ status: 'PROCESSING' | 'DONE' }>`
   padding: ${({ theme }) => theme.spacing[1]} ${({ theme }) => theme.spacing[2]};
   border-radius: 16px;
   background-color: ${({ theme, status }) => theme.colors.feedback[status]};
+`;
+
+const ContentBox = styled.div`
+  margin-bottom: ${({ theme }) => theme.spacing[2]};
 `;
 
 const LinkButton = styled.button`

--- a/src/pages/feedback/components/PendingTab.tsx
+++ b/src/pages/feedback/components/PendingTab.tsx
@@ -1,0 +1,5 @@
+const PendingTab = () => {
+  return <div>Waiting Feedback</div>;
+};
+
+export default PendingTab;

--- a/src/pages/feedback/components/PendingTab.tsx
+++ b/src/pages/feedback/components/PendingTab.tsx
@@ -1,5 +1,37 @@
+import { useOutletContext } from 'react-router-dom';
+import type { FeedbackData } from '../mocks/feedback';
+import FeedbackItem from './FeedbackItem';
+import styled from '@emotion/styled';
+
 const PendingTab = () => {
-  return <div>Waiting Feedback</div>;
+  const { feedbackData } = useOutletContext<{ feedbackData: FeedbackData[] }>();
+  const pendingList = feedbackData.filter(
+    (feedback) => feedback.status === 'PROCESSING',
+  );
+
+  return (
+    <Container>
+      {pendingList.map((feedback) => (
+        <FeedbackItem
+          key={feedback.id}
+          satisfaction={feedback.rating}
+          tag={feedback.type}
+          createAt={feedback.createdAt}
+          content={feedback.modifiedContent}
+          reply={feedback.reply}
+          status={feedback.status}
+        />
+      ))}
+    </Container>
+  );
 };
 
 export default PendingTab;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: ${({ theme }) => `${theme.spacing[2]} ${theme.spacing[6]}`};
+  gap: ${({ theme }) => theme.spacing[4]};
+`;

--- a/src/pages/feedback/components/PendingTab.tsx
+++ b/src/pages/feedback/components/PendingTab.tsx
@@ -4,10 +4,9 @@ import FeedbackItem from './FeedbackItem';
 import styled from '@emotion/styled';
 
 const PendingTab = () => {
-  const { feedbackData } = useOutletContext<{ feedbackData: FeedbackData[] }>();
-  const pendingList = feedbackData.filter(
-    (feedback) => feedback.status === 'PROCESSING',
-  );
+  const { pendingList } = useOutletContext<{
+    pendingList: FeedbackData[];
+  }>();
 
   return (
     <Container>

--- a/src/pages/feedback/components/TabNavigation.tsx
+++ b/src/pages/feedback/components/TabNavigation.tsx
@@ -1,0 +1,80 @@
+import Typography from '@/components/UI/Typography';
+import { ROUTE_PATH } from '@/routes/paths';
+import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
+
+type TabNavigationProps = {
+  selected: string;
+};
+
+const TabNavigation = ({ selected }: TabNavigationProps) => {
+  return (
+    <TabSection>
+      <TabContainer>
+        <TabItem
+          to={ROUTE_PATH.FEEDBACK_ALL}
+          isSelected={selected === ROUTE_PATH.FEEDBACK_ALL}
+        >
+          <Typography
+            variant='subtitle2'
+            color={selected === ROUTE_PATH.FEEDBACK_ALL ? 'white' : 'default'}
+          >
+            전체
+          </Typography>
+        </TabItem>
+        <TabItem
+          to={ROUTE_PATH.FEEDBACK_PENDING}
+          isSelected={selected === ROUTE_PATH.FEEDBACK_PENDING}
+        >
+          <Typography
+            variant='subtitle2'
+            color={
+              selected === ROUTE_PATH.FEEDBACK_PENDING ? 'white' : 'default'
+            }
+          >
+            대기 중
+          </Typography>
+        </TabItem>
+        <TabItem
+          to={ROUTE_PATH.FEEDBACK_COMPLETED}
+          isSelected={selected === ROUTE_PATH.FEEDBACK_COMPLETED}
+        >
+          <Typography
+            variant='subtitle2'
+            color={
+              selected === ROUTE_PATH.FEEDBACK_COMPLETED ? 'white' : 'default'
+            }
+          >
+            완료
+          </Typography>
+        </TabItem>
+      </TabContainer>
+    </TabSection>
+  );
+};
+
+export default TabNavigation;
+
+const TabSection = styled.section`
+  display: flex;
+  padding: ${({ theme }) => `${theme.spacing[2]} ${theme.spacing[5]}`};
+`;
+
+const TabContainer = styled.div`
+  width: 100%;
+  display: flex;
+  padding: ${({ theme }) => theme.spacing[2]};
+  gap: ${({ theme }) => theme.spacing[3]};
+`;
+
+const TabItem = styled(Link)<{ isSelected: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  border-radius: 20px;
+  padding: ${({ theme }) => theme.spacing[2]};
+  background-color: ${({ theme, isSelected }) =>
+    isSelected ? theme.colors.owner.main : theme.colors.gray[40]};
+  cursor: pointer;
+`;

--- a/src/pages/feedback/components/TabNavigation.tsx
+++ b/src/pages/feedback/components/TabNavigation.tsx
@@ -5,9 +5,17 @@ import { Link } from 'react-router-dom';
 
 type TabNavigationProps = {
   selected: string;
+  allCount: number;
+  pendingCount: number;
+  completedCount: number;
 };
 
-const TabNavigation = ({ selected }: TabNavigationProps) => {
+const TabNavigation = ({
+  selected,
+  allCount,
+  pendingCount,
+  completedCount,
+}: TabNavigationProps) => {
   return (
     <TabSection>
       <TabContainer>
@@ -19,7 +27,7 @@ const TabNavigation = ({ selected }: TabNavigationProps) => {
             variant='subtitle2'
             color={selected === ROUTE_PATH.FEEDBACK_ALL ? 'white' : 'default'}
           >
-            전체
+            전체({allCount})
           </Typography>
         </TabItem>
         <TabItem
@@ -32,7 +40,7 @@ const TabNavigation = ({ selected }: TabNavigationProps) => {
               selected === ROUTE_PATH.FEEDBACK_PENDING ? 'white' : 'default'
             }
           >
-            대기 중
+            대기 중({pendingCount})
           </Typography>
         </TabItem>
         <TabItem
@@ -45,7 +53,7 @@ const TabNavigation = ({ selected }: TabNavigationProps) => {
               selected === ROUTE_PATH.FEEDBACK_COMPLETED ? 'white' : 'default'
             }
           >
-            완료
+            완료({completedCount})
           </Typography>
         </TabItem>
       </TabContainer>

--- a/src/pages/feedback/components/TabNavigation.tsx
+++ b/src/pages/feedback/components/TabNavigation.tsx
@@ -57,11 +57,14 @@ export default TabNavigation;
 
 const TabSection = styled.section`
   display: flex;
+  align-items: center;
+  justify-content: center;
   padding: ${({ theme }) => `${theme.spacing[2]} ${theme.spacing[5]}`};
 `;
 
 const TabContainer = styled.div`
   width: 100%;
+  max-width: 550px;
   display: flex;
   padding: ${({ theme }) => theme.spacing[2]};
   gap: ${({ theme }) => theme.spacing[3]};

--- a/src/pages/feedback/mocks/feedback.ts
+++ b/src/pages/feedback/mocks/feedback.ts
@@ -1,0 +1,109 @@
+export const feedbackData = [
+  {
+    id: 5,
+    rating: 3,
+    modifiedContent:
+      '음식이 전반적으로 식은 상태로 제공되어 아쉬웠습니다.\n- 조리 후 제공 시 온도를 유지할 방법을 마련해주세요.\n- 음식 온도 관리에 신경 써주시면 좋겠습니다.',
+    reply: null,
+    type: 'complain',
+    status: 'PROCESSING',
+    createdAt: '2025-08-18',
+  },
+  {
+    id: 6,
+    rating: 2,
+    modifiedContent:
+      '주문 후 음식이 나오기까지 시간이 너무 오래 걸렸습니다.\n- 조리 및 서빙 속도를 개선해 주세요.\n- 손님 대기 시간을 줄일 수 있는 대책이 필요합니다.',
+    reply: null,
+    type: 'complain',
+    status: 'PROCESSING',
+    createdAt: '2025-08-19',
+  },
+  {
+    id: 7,
+    rating: 4,
+    modifiedContent:
+      '일부 메뉴의 양이 사진보다 적게 나오는 것 같습니다.\n- 실제 양과 메뉴판 사진이 일치하도록 조정 부탁드립니다.\n- 푸짐한 양을 유지해 주시면 만족도가 더 높아질 것 같습니다.',
+    reply: null,
+    type: 'complain',
+    status: 'PROCESSING',
+    createdAt: '2025-08-19',
+  },
+  {
+    id: 8,
+    rating: 3,
+    modifiedContent:
+      '매장이 다소 소란스러워 식사하기 불편했습니다.\n- 테이블 간격을 조금 더 두거나 소음 관리를 해주시면 좋을 것 같습니다.\n- 쾌적한 분위기 개선을 부탁드립니다.',
+    reply: null,
+    type: 'complain',
+    status: 'PROCESSING',
+    createdAt: '2025-08-20',
+  },
+  {
+    id: 9,
+    rating: 5,
+    modifiedContent:
+      '음식 맛은 훌륭하지만 배달 포장이 부실하여 국물이 흘렀습니다.\n- 밀폐력이 좋은 용기를 사용해주시면 좋겠습니다.\n- 배달 전 포장 상태를 한 번 더 확인 부탁드립니다.',
+    reply:
+      '불편을 드려 죄송합니다. 배달 포장 방식을 개선하여 국물이 새지 않도록 더욱 신경 쓰겠습니다. 앞으로도 최선의 서비스를 제공하도록 하겠습니다.',
+    type: 'complain',
+    status: 'DONE',
+    createdAt: '2025-08-20',
+  },
+  {
+    id: 10,
+    rating: 2,
+    modifiedContent:
+      '직원분이 주문 내용을 제대로 확인하지 않아 잘못된 메뉴가 나왔습니다.\n- 주문 확인 절차를 강화해 주셨으면 합니다.\n- 고객 불편이 발생하지 않도록 주의 부탁드립니다.',
+    reply:
+      '주문 확인 절차를 강화하여 같은 실수가 반복되지 않도록 하겠습니다. 불편을 끼쳐 드려 깊이 사과드립니다.',
+    type: 'complain',
+    status: 'DONE',
+    createdAt: '2025-08-21',
+  },
+  {
+    id: 11,
+    rating: 3,
+    modifiedContent:
+      '반찬 가짓수가 적고 리필 요청 시 응대가 늦은 편이었습니다.\n- 다양한 반찬을 조금 더 준비해주시면 좋겠습니다.\n- 빠른 리필 서비스가 필요할 것 같습니다.',
+    reply:
+      '반찬 가짓수를 늘리고 리필 요청에도 신속히 대응할 수 있도록 서비스 개선에 힘쓰겠습니다.',
+    type: 'complain',
+    status: 'DONE',
+    createdAt: '2025-08-21',
+  },
+  {
+    id: 12,
+    rating: 4,
+    modifiedContent:
+      '메뉴 설명이 부족해서 처음 방문한 사람은 선택하기 어려웠습니다.\n- 상세한 메뉴 설명이나 사진을 추가해 주세요.\n- 고객이 쉽게 선택할 수 있도록 안내가 필요합니다.',
+    reply:
+      '메뉴 설명과 사진을 추가하여 고객님들이 편리하게 선택할 수 있도록 개선하겠습니다.',
+    type: 'complain',
+    status: 'DONE',
+    createdAt: '2025-08-21',
+  },
+  {
+    id: 13,
+    rating: 2,
+    modifiedContent:
+      '매장 위생 상태가 깔끔하지 않아 불편했습니다.\n- 테이블과 바닥 청결 관리에 신경 써주세요.\n- 위생 점검을 강화해 주시길 바랍니다.',
+    reply:
+      '매장 위생 상태를 최우선으로 관리하고 주기적인 점검을 통해 청결한 환경을 유지하도록 하겠습니다.',
+    type: 'complain',
+    status: 'DONE',
+    createdAt: '2025-08-22',
+  },
+  {
+    id: 14,
+    rating: 3,
+    modifiedContent:
+      '음식이 전반적으로 기름져서 부담스럽습니다.\n- 조리 시 기름 양을 줄여주세요.\n- 담백한 메뉴 옵션을 추가하면 좋겠습니다.',
+    reply: null,
+    type: 'complain',
+    status: 'PROCESSING',
+    createdAt: '2025-08-22',
+  },
+] as const;
+
+export type FeedbackData = (typeof feedbackData)[number];

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -17,5 +17,8 @@ export const ROUTE_PATH = {
   COUPON: '/coupon',
 
   FEEDBACK: '/feedback',
+  FEEDBACK_ALL: '/feedback/all',
+  FEEDBACK_COMPLETED: '/feedback/completed',
+  FEEDBACK_PENDING: '/feedback/pending',
   INTERACTION: '/interaction',
 };

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import { ROUTE_PATH } from './paths';
 import MainPage from '@/pages/main/MainPage';
 import LandingPage from '@/pages/landing/LandingPage';
@@ -15,6 +15,10 @@ import CustomerMyPage from '@/pages/my/customer/CustomerMyPage';
 import OwnerMyPage from '@/pages/my/owner/OwnerMyPage';
 import MyCouponPage from '@/pages/my/customer/coupon/MyCouponPage';
 import MyLetterPage from '@/pages/my/customer/letter/MyLetterPage';
+import FeedbackPage from '@/pages/feedback/FeedbackPage';
+import CompletedTab from '@/pages/feedback/components/CompletedTab';
+import AllTab from '@/pages/feedback/components/AllTab';
+import PendingTab from '@/pages/feedback/components/PendingTab';
 
 const Router = () => {
   return (
@@ -36,6 +40,18 @@ const Router = () => {
           <Route path={ROUTE_PATH.MY_LETTER} element={<MyLetterPage />} />
         </Route>
         <Route path={ROUTE_PATH.MY_OWNER} element={<OwnerMyPage />} />
+      </Route>
+      <Route path={ROUTE_PATH.FEEDBACK} element={<FeedbackPage />}>
+        <Route
+          index
+          element={<Navigate to={ROUTE_PATH.FEEDBACK_ALL} replace />}
+        />
+        <Route path={ROUTE_PATH.FEEDBACK_ALL} element={<AllTab />} />
+        <Route
+          path={ROUTE_PATH.FEEDBACK_COMPLETED}
+          element={<CompletedTab />}
+        />
+        <Route path={ROUTE_PATH.FEEDBACK_PENDING} element={<PendingTab />} />
       </Route>
     </Routes>
   );

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -39,6 +39,10 @@ export const theme = {
       improve: '#dbe9fe',
       complain: '#ffdcda',
     },
+    feedback: {
+      PROCESSING: '#FFF7ED',
+      DONE: '#EEF7FF',
+    },
     // 텍스트 색상
     text: {
       default: gray[90], // 기본 텍스트


### PR DESCRIPTION
## ✨ 요약

> PR의 목적을 한두 문장으로 요약합니다.

사장님의 피드백 관리 페이지를 구현하였습니다. 

## 🔗 작업 내용

- [x] 피드백 관리 페이지 구현
  - [x] 하위 페이지를 전체, 읽지 않음, 완료 3가지로 구분하여 구성
  - [x] AI 추천 개선사항, 사장님 답변을 피드백과 함께 카드로 구성

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

피드백 관리 페이지를 mock 데이터에서 가져와 분류하여 볼 수 있도록 구현하였습니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

답변하기 버튼 클릭 시 답변을 작성할 수 있는 모달 구현이 필요합니다. 

## 📸 스크린샷 (Screenshots)
<img width="278" height="600" alt="image" src="https://github.com/user-attachments/assets/f6b01a50-50a5-4fec-8b5d-7f95085e8d2c" />


## 🔗 관련 이슈

- Close #28 
