### PR TITLE
feat: 지도 페이지 API 연동 및 피드백 보내기까지 API 로직 구현 완료

### DIFF
--- a/src/api/announcement/postAnnouncement.ts
+++ b/src/api/announcement/postAnnouncement.ts
@@ -1,0 +1,14 @@
+import { API_PATHS } from '@/api/paths';
+import axiosInstance from '@/api/axiosInstance';
+
+export type PostAnnouncementParams = {
+  storeId: string;
+  feedbackId: string;
+  description: string;
+};
+
+export const postAnnouncement = async (
+  params: PostAnnouncementParams,
+): Promise<void> => {
+  return await axiosInstance.post(API_PATHS.ANNOUNCEMENT, params);
+};

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,3 +1,4 @@
+import { SESSION_AUTH_KEY } from '@/constants/storageKeys';
 import axios from 'axios';
 
 const axiosInstance = axios.create({
@@ -6,6 +7,14 @@ const axiosInstance = axios.create({
     'Content-Type': 'application/json',
   },
   timeout: 5000,
+});
+
+axiosInstance.interceptors.request.use((config) => {
+  const token = sessionStorage.getItem(SESSION_AUTH_KEY);
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
 });
 
 axiosInstance.interceptors.response.use(

--- a/src/api/feedback/getStoreFeedback.ts
+++ b/src/api/feedback/getStoreFeedback.ts
@@ -21,9 +21,6 @@ export const getStoreFeedbacks = async (
   const response: CustomAxiosResponse<Feedback[]> = await axiosInstance.get(
     API_PATHS.FEEDBACK,
     {
-      headers: {
-        Authorization: `Bearer ${params.accessToken}`,
-      },
       params: {
         storeId: params.storeId,
         ...(params.type && { type: params.type }),

--- a/src/api/feedback/getStoreFeedback.ts
+++ b/src/api/feedback/getStoreFeedback.ts
@@ -1,0 +1,34 @@
+import { API_PATHS } from '@/api/paths';
+import axiosInstance from '@/api/axiosInstance';
+
+type CustomAxiosResponse<T> = {
+  content: T;
+  status: string;
+  message: string;
+};
+
+export type getStoreFeedbackParams = {
+  storeId: string;
+  accessToken: string;
+  type?: 'UNREAD' | 'DONE';
+};
+
+export type getStoreFeedbackResult = Feedback[];
+
+export const getStoreFeedbacks = async (
+  params: getStoreFeedbackParams,
+): Promise<getStoreFeedbackResult> => {
+  const response: CustomAxiosResponse<Feedback[]> = await axiosInstance.get(
+    API_PATHS.FEEDBACK,
+    {
+      headers: {
+        Authorization: `Bearer ${params.accessToken}`,
+      },
+      params: {
+        storeId: params.storeId,
+        ...(params.type && { type: params.type }),
+      },
+    },
+  );
+  return response.content;
+};

--- a/src/api/feedback/postFeedback.ts
+++ b/src/api/feedback/postFeedback.ts
@@ -1,0 +1,21 @@
+import axiosInstance from '@/api/axiosInstance';
+import { API_PATHS } from '@/api/paths';
+
+export type FeedbackType = 'COMPLIMENT' | 'SUGGESTION' | 'COMPLAINT';
+
+export type CreateFeedbackRequest = {
+  storeId: number;
+  rating: number;
+  content: string;
+  type: FeedbackType;
+  receiptId: number;
+};
+
+export type CreateFeedbackResponse = { message: string };
+
+export async function createFeedback(
+  body: CreateFeedbackRequest,
+): Promise<CreateFeedbackResponse> {
+  // axiosInstance가 응답을 data로 언랩해주므로 여기서는 그대로 반환
+  return await axiosInstance.post(API_PATHS.FEEDBACK ?? '/api/feedbacks', body);
+}

--- a/src/api/getRequiredAccessToken.ts
+++ b/src/api/getRequiredAccessToken.ts
@@ -1,0 +1,9 @@
+// src/api/getRequiredAccessToken.ts
+export function getRequiredAccessToken(): string {
+  const t = localStorage.getItem('accessToken');
+  if (!t) {
+    // 여기서 바로 막아버림 (로그인 페이지 이동 or 에러 throw)
+    throw new Error('MISSING_ACCESS_TOKEN');
+  }
+  return t; // 이제부터는 확실히 string
+}

--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -6,4 +6,5 @@ export const API_PATHS = {
   STORE_LIST: '/api/store/list',
   STORE_DETAIL: (id: string | number) => `/api/store/${id}`,
   FEEDBACK: `/api/feedbacks`,
+  ANNOUNCEMENT: `/api/announcement`,
 };

--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -2,9 +2,9 @@ export const API_PATHS = {
   LOGIN: '/api/auth/login',
   LOGOUT: '/api/auth/logout',
   SIGNUP: '/api/auth/signup',
+  FEEDBACK: `/api/feedbacks`,
+  ANNOUNCEMENT: `/api/announcement`,
 
   STORE_LIST: '/api/store/list',
   STORE_DETAIL: (id: string | number) => `/api/store/${id}`,
-  FEEDBACK: `/api/feedbacks`,
-  ANNOUNCEMENT: `/api/announcement`,
 };

--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -2,4 +2,8 @@ export const API_PATHS = {
   LOGIN: '/api/auth/login',
   LOGOUT: '/api/auth/logout',
   SIGNUP: '/api/auth/signup',
+
+  STORE_LIST: '/api/store/list',
+  STORE_DETAIL: (id: string | number) => `/api/store/${id}`,
+  FEEDBACK: '/api/feedback/list',
 };

--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -5,5 +5,5 @@ export const API_PATHS = {
 
   STORE_LIST: '/api/store/list',
   STORE_DETAIL: (id: string | number) => `/api/store/${id}`,
-  FEEDBACK: '/api/feedback/list',
+  FEEDBACK: `/api/feedbacks`,
 };

--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -6,5 +6,5 @@ export const API_PATHS = {
   ANNOUNCEMENT: `/api/announcement`,
 
   STORE_LIST: '/api/store/list',
-  STORE_DETAIL: (id: string | number) => `/api/store/${id}`,
+  STORE_DETAIL: (id: number) => `/api/store/${id}`,
 };

--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -3,8 +3,8 @@ export const API_PATHS = {
   LOGOUT: '/api/auth/logout',
   SIGNUP: '/api/auth/signup',
   FEEDBACK: `/api/feedbacks`,
+  RECEIPT: '/api/receipt/ocr',
   ANNOUNCEMENT: `/api/announcement`,
-
   STORE_LIST: '/api/store/list',
   STORE_DETAIL: (id: number) => `/api/store/${id}`,
 };

--- a/src/api/receipt/receipt.ts
+++ b/src/api/receipt/receipt.ts
@@ -1,0 +1,26 @@
+import axiosInstance from '@/api/axiosInstance';
+import { API_PATHS } from '@/api/paths';
+
+export type OcrStatus = 'AVAILABLE' | 'PENDING' | 'REJECTED'; // 백엔드 값에 맞춰 필요시 보강
+export type OcrReceiptResponse = {
+  id: number;
+  storeName: string;
+  address: string;
+  dateTime: string; // "yyyy-MM-dd HH:mm:ss"
+  totalPrice: number;
+  status: OcrStatus;
+};
+
+export async function uploadReceiptOcr(
+  file: File,
+): Promise<OcrReceiptResponse> {
+  const form = new FormData();
+  form.append('image', file);
+
+  // axiosInstance가 기본으로 'application/json'을 넣고 있으므로 여기서 덮어쓰기
+  return await axiosInstance.post<OcrReceiptResponse, OcrReceiptResponse>(
+    API_PATHS.RECEIPT,
+    form,
+    { headers: { 'Content-Type': 'multipart/form-data' } },
+  );
+}

--- a/src/api/store/store.ts
+++ b/src/api/store/store.ts
@@ -1,6 +1,7 @@
 import axiosInstance from '@/api/axiosInstance';
 import { API_PATHS } from '@/api/paths';
 
+/** 리스트 아이템 타입 */
 export type StoreListItem = {
   id: number;
   name: string;
@@ -41,26 +42,21 @@ export type StoreDetailDTO = StoreListItem & {
   }>;
 };
 
-// 리스트 조회 (토큰 필요)
-
-export async function fetchStoreList(
-  params: { keyword?: string; latitude?: number; longitude?: number },
-  accessToken: string, // ← 반드시 필요하도록 명시
-) {
-  const res = await axiosInstance.get('/api/store/list', {
-    params,
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
-  return res.data;
+export async function fetchStoreList(params: {
+  keyword?: string;
+  latitude?: number;
+  longitude?: number;
+}): Promise<StoreListItem[]> {
+  const data = await axiosInstance.get<StoreListItem[], StoreListItem[]>(
+    API_PATHS.STORE_LIST ?? '/api/store/list',
+    { params },
+  );
+  return data; // <- 이미 T로 언랩됨
 }
 
-export async function fetchStoreDetail(
-  id: number,
-  accessToken: string,
-): Promise<StoreDetailDTO> {
-  const res = await axiosInstance.get<StoreDetailDTO>(
-    API_PATHS.STORE_DETAIL(id),
-    { headers: { Authorization: `Bearer ${accessToken}` } },
+export async function fetchStoreDetail(id: number): Promise<StoreDetailDTO> {
+  const data = await axiosInstance.get<StoreDetailDTO, StoreDetailDTO>(
+    API_PATHS.STORE_DETAIL ? API_PATHS.STORE_DETAIL(id) : `/api/store/${id}`,
   );
-  return res.data;
+  return data; // <- 이미 T로 언랩됨
 }

--- a/src/api/store/store.ts
+++ b/src/api/store/store.ts
@@ -25,7 +25,7 @@ export type StoreListItem = {
 
 export type StoreDetailDTO = StoreListItem & {
   userId: number;
-  menus: Array<{
+  menuList: Array<{
     id: number;
     storeId: number;
     name: string;
@@ -33,7 +33,8 @@ export type StoreDetailDTO = StoreListItem & {
     description?: string;
     imageUrl?: string;
   }>;
-  storeAnnouncements: Array<{
+  announcementList: Array<{
+    description?: string;
     id: number;
     storeId: number;
     feedbackId: number;

--- a/src/api/store/store.ts
+++ b/src/api/store/store.ts
@@ -1,0 +1,66 @@
+import axiosInstance from '@/api/axiosInstance';
+import { API_PATHS } from '@/api/paths';
+
+export type StoreListItem = {
+  id: number;
+  name: string;
+  canonicalName?: string;
+  address?: string;
+  latitude: number;
+  longitude: number;
+  description?: string;
+  category?:
+    | 'KOREAN'
+    | 'CHINESE'
+    | 'JAPANESE'
+    | 'WESTERN'
+    | 'CAFE'
+    | 'FASTFOOD'
+    | 'BAR'
+    | 'OTHERS';
+  imageUrl?: string;
+  openingTime?: string;
+};
+
+export type StoreDetailDTO = StoreListItem & {
+  userId: number;
+  menus: Array<{
+    id: number;
+    storeId: number;
+    name: string;
+    price: number;
+    description?: string;
+    imageUrl?: string;
+  }>;
+  storeAnnouncements: Array<{
+    id: number;
+    storeId: number;
+    feedbackId: number;
+    feedbackContent: string;
+    content: string;
+  }>;
+};
+
+// 리스트 조회 (토큰 필요)
+
+export async function fetchStoreList(
+  params: { keyword?: string; latitude?: number; longitude?: number },
+  accessToken: string, // ← 반드시 필요하도록 명시
+) {
+  const res = await axiosInstance.get('/api/store/list', {
+    params,
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  return res.data;
+}
+
+export async function fetchStoreDetail(
+  id: number,
+  accessToken: string,
+): Promise<StoreDetailDTO> {
+  const res = await axiosInstance.get<StoreDetailDTO>(
+    API_PATHS.STORE_DETAIL(id),
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+  return res.data;
+}

--- a/src/constants/letter.ts
+++ b/src/constants/letter.ts
@@ -1,7 +1,7 @@
 export const LetterTag = [
-  { value: 'positive', label: '칭찬' },
-  { value: 'improve', label: '제안' },
-  { value: 'complain', label: '불만' },
+  { value: 'COMPLIMENT', label: '칭찬' },
+  { value: 'SUGGESTION', label: '제안' },
+  { value: 'COMPLAINT', label: '불만' },
 ] as const;
 
 export type LetterTagType = (typeof LetterTag)[number]['value'];

--- a/src/pages/feedback/FeedbackPage.tsx
+++ b/src/pages/feedback/FeedbackPage.tsx
@@ -4,20 +4,31 @@ import { HEADER_HEIGHT, NAV_HEIGHT } from '@/constants/number';
 import styled from '@emotion/styled';
 import TabNavigation from './components/TabNavigation';
 import { Outlet, useLocation } from 'react-router-dom';
-import { feedbackData, type FeedbackData } from './mocks/feedback';
+import useFeedback from './hooks/useFeedback';
+import { useAuth } from '@/contexts/AuthContext';
 
 export type FeedbackContextType = {
-  feedbackData: FeedbackData[];
-  pendingList: FeedbackData[];
-  completedList: FeedbackData[];
+  feedbackData: Feedback[];
+  unReadData: Feedback[];
+  completedData: Feedback[];
 };
 
 const FeedbackPage = () => {
   const location = useLocation();
-  const pendingList = feedbackData.filter(
-    (feedback) => feedback.status === 'PROCESSING',
+  const user = useAuth();
+  const { feedbackData, isLoading } = useFeedback({
+    storeId: '1',
+    accessToken: user?.accessToken || '',
+  });
+
+  if (isLoading || !feedbackData) {
+    return <div>Loading...</div>;
+  }
+
+  const unReadData = feedbackData.filter(
+    (feedback) => feedback.status === 'UNREAD',
   );
-  const completedList = feedbackData.filter(
+  const completedData = feedbackData.filter(
     (feedback) => feedback.status === 'DONE',
   );
 
@@ -28,10 +39,10 @@ const FeedbackPage = () => {
         <TabNavigation
           selected={location.pathname}
           allCount={feedbackData.length}
-          pendingCount={pendingList.length}
-          completedCount={completedList.length}
+          pendingCount={unReadData.length}
+          completedCount={completedData.length}
         />
-        <Outlet context={{ feedbackData, pendingList, completedList }} />
+        <Outlet context={{ feedbackData, unReadData, completedData }} />
       </Main>
       <NavigationOwner />
     </>

--- a/src/pages/feedback/FeedbackPage.tsx
+++ b/src/pages/feedback/FeedbackPage.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import TabNavigation from './components/TabNavigation';
 import { Outlet, useLocation } from 'react-router-dom';
 import useFeedback from './hooks/useFeedback';
-import { useAuth } from '@/contexts/AuthContext';
 
 export type FeedbackContextType = {
   feedbackData: Feedback[];
@@ -15,10 +14,8 @@ export type FeedbackContextType = {
 
 const FeedbackPage = () => {
   const location = useLocation();
-  const user = useAuth();
   const { feedbackData, isLoading } = useFeedback({
     storeId: '1',
-    accessToken: user?.accessToken || '',
   });
 
   if (isLoading || !feedbackData) {

--- a/src/pages/feedback/components/AllTab.tsx
+++ b/src/pages/feedback/components/AllTab.tsx
@@ -17,6 +17,8 @@ const AllTab = () => {
           modifiedContent={feedback.modifiedContent}
           reply={feedback.reply}
           status={feedback.status}
+          feedbackId={feedback.id.toString()}
+          storeId={'1'}
         />
       ))}
     </Container>

--- a/src/pages/feedback/components/AllTab.tsx
+++ b/src/pages/feedback/components/AllTab.tsx
@@ -1,7 +1,7 @@
-import { useOutletContext } from 'react-router-dom';
 import FeedbackItem from './FeedbackItem';
 import styled from '@emotion/styled';
 import type { FeedbackContextType } from '../FeedbackPage';
+import { useOutletContext } from 'react-router-dom';
 
 const AllTab = () => {
   const { feedbackData } = useOutletContext<FeedbackContextType>();

--- a/src/pages/feedback/components/AllTab.tsx
+++ b/src/pages/feedback/components/AllTab.tsx
@@ -13,7 +13,7 @@ const AllTab = () => {
           key={feedback.id}
           rating={feedback.rating}
           type={feedback.type}
-          createAt={feedback.createdAt}
+          createdAt={feedback.createdAt}
           modifiedContent={feedback.modifiedContent}
           reply={feedback.reply}
           status={feedback.status}

--- a/src/pages/feedback/components/CompletedTab.tsx
+++ b/src/pages/feedback/components/CompletedTab.tsx
@@ -13,7 +13,7 @@ const CompletedTab = () => {
           key={feedback.id}
           rating={feedback.rating}
           type={feedback.type}
-          createAt={feedback.createdAt}
+          createdAt={feedback.createdAt}
           modifiedContent={feedback.modifiedContent}
           reply={feedback.reply}
           status={feedback.status}

--- a/src/pages/feedback/components/CompletedTab.tsx
+++ b/src/pages/feedback/components/CompletedTab.tsx
@@ -17,6 +17,8 @@ const CompletedTab = () => {
           modifiedContent={feedback.modifiedContent}
           reply={feedback.reply}
           status={feedback.status}
+          feedbackId={feedback.id.toString()}
+          storeId={'1'}
         />
       ))}
     </Container>

--- a/src/pages/feedback/components/CompletedTab.tsx
+++ b/src/pages/feedback/components/CompletedTab.tsx
@@ -4,11 +4,11 @@ import styled from '@emotion/styled';
 import type { FeedbackContextType } from '../FeedbackPage';
 
 const CompletedTab = () => {
-  const { completedList } = useOutletContext<FeedbackContextType>();
+  const { completedData } = useOutletContext<FeedbackContextType>();
 
   return (
     <Container>
-      {completedList.map((feedback) => (
+      {completedData.map((feedback) => (
         <FeedbackItem
           key={feedback.id}
           rating={feedback.rating}

--- a/src/pages/feedback/components/FeedbackItem.tsx
+++ b/src/pages/feedback/components/FeedbackItem.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Star } from 'lucide-react';
 import DoneSection from './DoneSection';
-import ProcessingSection from './ProcessingSection';
+import UnReadSection from './ProcessingSection';
 
 type FeedbackItemProps = {
   rating: number;
@@ -13,6 +13,8 @@ type FeedbackItemProps = {
   modifiedContent: string;
   reply: string | null;
   status: 'UNREAD' | 'DONE';
+  feedbackId: string;
+  storeId: string;
 };
 
 const FeedbackItem = ({
@@ -22,6 +24,8 @@ const FeedbackItem = ({
   modifiedContent,
   reply,
   status,
+  feedbackId,
+  storeId,
 }: FeedbackItemProps) => {
   const theme = useTheme();
 
@@ -47,7 +51,7 @@ const FeedbackItem = ({
           </TagBox>
           <StatusBox status={status}>
             <Typography variant='body2'>
-              {status === 'UNREAD' ? '처리 중' : '완료'}
+              {status === 'UNREAD' ? '대기 중' : '완료'}
             </Typography>
           </StatusBox>
         </Wrapper>
@@ -56,7 +60,11 @@ const FeedbackItem = ({
       <ContentBox>
         <Typography variant='body1'>{modifiedContent}</Typography>
       </ContentBox>
-      {reply ? <DoneSection reply={reply} /> : <ProcessingSection />}
+      {reply ? (
+        <DoneSection reply={reply} />
+      ) : (
+        <UnReadSection storeId={storeId} feedbackId={feedbackId} />
+      )}
     </Card>
   );
 };

--- a/src/pages/feedback/components/FeedbackItem.tsx
+++ b/src/pages/feedback/components/FeedbackItem.tsx
@@ -4,12 +4,12 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Star } from 'lucide-react';
 import DoneSection from './DoneSection';
-import UnReadSection from './ProcessingSection';
+import UnReadSection from './UnReadSection';
 
 type FeedbackItemProps = {
   rating: number;
   type: LetterTagType;
-  createAt: string;
+  createdAt: string;
   modifiedContent: string;
   reply: string | null;
   status: 'UNREAD' | 'DONE';
@@ -20,7 +20,7 @@ type FeedbackItemProps = {
 const FeedbackItem = ({
   rating,
   type,
-  createAt,
+  createdAt,
   modifiedContent,
   reply,
   status,
@@ -55,7 +55,7 @@ const FeedbackItem = ({
             </Typography>
           </StatusBox>
         </Wrapper>
-        <Typography variant='body2'>{createAt}</Typography>
+        <Typography variant='body2'>{createdAt}</Typography>
       </LineWrapper>
       <ContentBox>
         <Typography variant='body1'>{modifiedContent}</Typography>

--- a/src/pages/feedback/components/FeedbackItem.tsx
+++ b/src/pages/feedback/components/FeedbackItem.tsx
@@ -12,7 +12,7 @@ type FeedbackItemProps = {
   createAt: string;
   modifiedContent: string;
   reply: string | null;
-  status: 'PROCESSING' | 'DONE';
+  status: 'UNREAD' | 'DONE';
 };
 
 const FeedbackItem = ({
@@ -47,7 +47,7 @@ const FeedbackItem = ({
           </TagBox>
           <StatusBox status={status}>
             <Typography variant='body2'>
-              {status === 'PROCESSING' ? '처리 중' : '완료'}
+              {status === 'UNREAD' ? '처리 중' : '완료'}
             </Typography>
           </StatusBox>
         </Wrapper>
@@ -63,7 +63,7 @@ const FeedbackItem = ({
 
 export default FeedbackItem;
 
-const Card = styled.div<{ status?: 'PROCESSING' | 'DONE' }>`
+const Card = styled.div<{ status?: 'UNREAD' | 'DONE' }>`
   display: flex;
   flex-direction: column;
   background-color: ${({ theme, status }) =>
@@ -102,7 +102,7 @@ const TagBox = styled.div<{ tag: LetterTagType }>`
   background-color: ${({ theme, tag }) => theme.colors.tag[tag]};
 `;
 
-const StatusBox = styled.div<{ status: 'PROCESSING' | 'DONE' }>`
+const StatusBox = styled.div<{ status: 'UNREAD' | 'DONE' }>`
   display: flex;
   align-items: center;
   padding: ${({ theme }) => theme.spacing[1]} ${({ theme }) => theme.spacing[2]};

--- a/src/pages/feedback/components/ProcessingSection.tsx
+++ b/src/pages/feedback/components/ProcessingSection.tsx
@@ -2,17 +2,28 @@ import Typography from '@/components/UI/Typography';
 import styled from '@emotion/styled';
 import { Bot, Heart } from 'lucide-react';
 import { useState } from 'react';
+import useAnnouncement from '../hooks/useAnnouncement';
 
-const ProcessingSection = () => {
+type UnReadSectionProps = {
+  storeId: string;
+  feedbackId: string;
+};
+
+const UnReadSection = ({ storeId, feedbackId }: UnReadSectionProps) => {
   const [processing, setProcessing] = useState(false);
   const [reply, setReply] = useState('');
+  const { postAnnouncement } = useAnnouncement({
+    feedbackId,
+    storeId,
+    description: reply,
+  });
   const handleClickAnswer = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     setProcessing(true);
   };
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setReply('');
+    postAnnouncement();
     setProcessing(false);
   };
 
@@ -58,12 +69,12 @@ const ProcessingSection = () => {
   );
 };
 
-export default ProcessingSection;
+export default UnReadSection;
 
 const Card = styled.div`
   display: flex;
   flex-direction: column;
-  background-color: ${({ theme }) => theme.colors.feedback.PROCESSING};
+  background-color: ${({ theme }) => theme.colors.feedback.UNREAD};
   border-radius: 16px;
   gap: ${({ theme }) => theme.spacing[3]};
   padding: ${({ theme }) => `${theme.spacing[4]} ${theme.spacing[5]}`};

--- a/src/pages/feedback/components/TabNavigation.tsx
+++ b/src/pages/feedback/components/TabNavigation.tsx
@@ -78,7 +78,9 @@ const TabContainer = styled.div`
   gap: ${({ theme }) => theme.spacing[3]};
 `;
 
-const TabItem = styled(Link)<{ isSelected: boolean }>`
+const TabItem = styled(Link, {
+  shouldForwardProp: (prop) => prop !== 'isSelected',
+})<{ isSelected: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/feedback/components/UnReadSection.tsx
+++ b/src/pages/feedback/components/UnReadSection.tsx
@@ -23,8 +23,12 @@ const UnReadSection = ({ storeId, feedbackId }: UnReadSectionProps) => {
   };
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    postAnnouncement();
-    setProcessing(false);
+    postAnnouncement(undefined, {
+      onSuccess: () => {
+        setReply('');
+        setProcessing(false);
+      },
+    });
   };
 
   return (

--- a/src/pages/feedback/components/UnReadTab.tsx
+++ b/src/pages/feedback/components/UnReadTab.tsx
@@ -17,6 +17,8 @@ const UnReadTab = () => {
           modifiedContent={feedback.modifiedContent}
           reply={feedback.reply}
           status={feedback.status}
+          feedbackId={feedback.id.toString()}
+          storeId={'1'}
         />
       ))}
     </Container>

--- a/src/pages/feedback/components/UnReadTab.tsx
+++ b/src/pages/feedback/components/UnReadTab.tsx
@@ -13,7 +13,7 @@ const UnReadTab = () => {
           key={feedback.id}
           rating={feedback.rating}
           type={feedback.type}
-          createAt={feedback.createdAt}
+          createdAt={feedback.createdAt}
           modifiedContent={feedback.modifiedContent}
           reply={feedback.reply}
           status={feedback.status}

--- a/src/pages/feedback/components/UnReadTab.tsx
+++ b/src/pages/feedback/components/UnReadTab.tsx
@@ -1,14 +1,14 @@
-import { useOutletContext } from 'react-router-dom';
 import FeedbackItem from './FeedbackItem';
 import styled from '@emotion/styled';
+import { useOutletContext } from 'react-router-dom';
 import type { FeedbackContextType } from '../FeedbackPage';
 
-const PendingTab = () => {
-  const { pendingList } = useOutletContext<FeedbackContextType>();
+const UnReadTab = () => {
+  const { unReadData } = useOutletContext<FeedbackContextType>();
 
   return (
     <Container>
-      {pendingList.map((feedback) => (
+      {unReadData?.map((feedback) => (
         <FeedbackItem
           key={feedback.id}
           rating={feedback.rating}
@@ -23,7 +23,7 @@ const PendingTab = () => {
   );
 };
 
-export default PendingTab;
+export default UnReadTab;
 
 const Container = styled.div`
   display: flex;

--- a/src/pages/feedback/hooks/useAnnouncement.ts
+++ b/src/pages/feedback/hooks/useAnnouncement.ts
@@ -1,0 +1,21 @@
+import { postAnnouncement } from '@/api/announcement/postAnnouncement';
+import { useMutation } from '@tanstack/react-query';
+type useAnnouncementParams = {
+  feedbackId: string;
+  storeId: string;
+  description: string;
+};
+
+const useAnnouncement = ({
+  feedbackId,
+  storeId,
+  description,
+}: useAnnouncementParams) => {
+  const { mutate } = useMutation({
+    mutationFn: () => postAnnouncement({ storeId, feedbackId, description }),
+  });
+
+  return { postAnnouncement: mutate };
+};
+
+export default useAnnouncement;

--- a/src/pages/feedback/hooks/useFeedback.ts
+++ b/src/pages/feedback/hooks/useFeedback.ts
@@ -3,14 +3,13 @@ import { useQuery } from '@tanstack/react-query';
 
 type useFeedbackParams = {
   storeId: string;
-  accessToken: string;
   type?: 'UNREAD' | 'DONE';
 };
 
-const useFeedback = ({ storeId, accessToken, type }: useFeedbackParams) => {
+const useFeedback = ({ storeId, type }: useFeedbackParams) => {
   const { data, isLoading } = useQuery<Feedback[]>({
     queryKey: ['feedback', storeId, type],
-    queryFn: () => getStoreFeedbacks({ storeId, accessToken, type }),
+    queryFn: () => getStoreFeedbacks({ storeId, type }),
   });
 
   return {

--- a/src/pages/feedback/hooks/useFeedback.ts
+++ b/src/pages/feedback/hooks/useFeedback.ts
@@ -1,0 +1,22 @@
+import { getStoreFeedbacks } from '@/api/feedback/getStoreFeedback';
+import { useQuery } from '@tanstack/react-query';
+
+type useFeedbackParams = {
+  storeId: string;
+  accessToken: string;
+  type?: 'UNREAD' | 'DONE';
+};
+
+const useFeedback = ({ storeId, accessToken, type }: useFeedbackParams) => {
+  const { data, isLoading } = useQuery<Feedback[]>({
+    queryKey: ['feedback', storeId, type],
+    queryFn: () => getStoreFeedbacks({ storeId, accessToken, type }),
+  });
+
+  return {
+    feedbackData: data,
+    isLoading,
+  };
+};
+
+export default useFeedback;

--- a/src/pages/letter/LetterPage.tsx
+++ b/src/pages/letter/LetterPage.tsx
@@ -5,24 +5,42 @@ import styled from '@emotion/styled';
 import UploadSection from './components/UploadSection';
 import useFile from './hooks/useFile';
 import LetterSendSection from './components/LetterSendSection';
-import { useState, type FormEvent } from 'react';
+import { useMemo, useState, type FormEvent } from 'react';
 import type { LetterTagType } from '@/constants/letter';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ROUTE_PATH } from '@/routes/paths';
+import { uploadReceiptOcr } from '@/api/receipt/receipt';
 import {
   createFeedback,
-  type FeedbackType,
   type CreateFeedbackRequest,
+  type FeedbackType,
 } from '@/api/feedback/postFeedback';
+
+// LetterTagType -> FeedbackType 매핑
+const typeMap: Record<LetterTagType, FeedbackType> = {
+  COMPLIMENT: 'COMPLIMENT',
+  SUGGESTION: 'SUGGESTION',
+  COMPLAINT: 'COMPLAINT',
+};
 
 const LetterPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { uploadedFile, isUploaded, handleFileChange } = useFile();
 
+  // StoreDetailPage에서 넘겨준 storeId는 state 또는 query에 실려있음
+  const storeId = useMemo(() => {
+    const s = (location.state as { storeId?: number } | null)?.storeId;
+    if (typeof s === 'number' && Number.isFinite(s)) return s;
+
+    const qs = new URLSearchParams(location.search);
+    const q = Number(qs.get('storeId'));
+    return Number.isFinite(q) ? q : null;
+  }, [location.state, location.search]);
+
+  const { uploadedFile, isUploaded, handleFileChange } = useFile();
   const [formData, setFormData] = useState<{
     satisfaction: number;
-    letterTag: LetterTagType; // 'positive' | 'suggestion' | 'complaint' 라고 가정
+    letterTag: LetterTagType;
     letterText: string;
   }>({
     satisfaction: 0,
@@ -31,78 +49,51 @@ const LetterPage = () => {
   });
 
   const [, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // StoreDetailPage에서 넘겨준 값 복구 (state 또는 query)
-  const search = new URLSearchParams(location.search);
-  const storeIdFromQuery = search.get('storeId');
-  const receiptIdFromQuery = search.get('receiptId');
-
-  const storeId: number | undefined =
-    (location.state as { storeId?: number } | null)?.storeId ??
-    (storeIdFromQuery ? Number(storeIdFromQuery) : undefined);
-
-  const receiptId: number | undefined =
-    (location.state as { receiptId?: number } | null)?.receiptId ??
-    (receiptIdFromQuery ? Number(receiptIdFromQuery) : undefined);
-
-  const typeMap: Record<LetterTagType, FeedbackType> = {
-    COMPLIMENT: 'COMPLIMENT',
-    SUGGESTION: 'SUGGESTION',
-    COMPLAINT: 'COMPLAINT',
-  };
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setError(null);
+    setErrorMsg(null);
 
-    // 기본 검증
-    if (!storeId) {
-      setError('가게 정보가 없습니다.');
-      alert('가게 정보가 없습니다.');
+    // 1) 선행 유효성
+    if (storeId == null) {
+      setErrorMsg('가게 정보가 없습니다. 다시 시도해주세요.');
       return;
     }
-    if (
-      !formData.satisfaction ||
-      formData.satisfaction < 1 ||
-      formData.satisfaction > 5
-    ) {
-      setError('별점을 선택해 주세요.');
-      alert('별점을 선택해 주세요.');
+    if (!isUploaded || !uploadedFile) {
+      setErrorMsg('영수증 이미지를 먼저 업로드해주세요.');
       return;
     }
     if (!formData.letterText.trim()) {
-      setError('내용을 입력해 주세요.');
-      alert('내용을 입력해 주세요.');
+      setErrorMsg('내용을 입력해주세요.');
       return;
     }
 
-    const rid = Number(receiptId);
-    const payload: CreateFeedbackRequest = {
-      storeId, // number
-      receiptId: rid,
-      rating: formData.satisfaction, // number
-      content: formData.letterText.trim(), // string
-      type: typeMap[formData.letterTag], // FeedbackType
-    };
-
+    setSubmitting(true);
     try {
-      setSubmitting(true);
+      // 2) 영수증 OCR 업로드 → receiptId 발급
+      const ocr = await uploadReceiptOcr(uploadedFile);
+      const receiptId = ocr.id;
 
-      if (import.meta.env.DEV) {
-        console.group('[Letter] createFeedback payload');
-        console.log(payload);
-        console.log('uploadedFile (클라이언트만):', uploadedFile);
-        console.groupEnd();
-      }
+      // 3) 피드백 생성 payload
+      const payload: CreateFeedbackRequest = {
+        storeId,
+        receiptId,
+        rating: formData.satisfaction,
+        content: formData.letterText.trim(),
+        type: typeMap[formData.letterTag],
+      };
 
-      const res = await createFeedback(payload);
-      alert(res?.message ?? '피드백이 등록되었습니다.');
+      // 4) 피드백 전송
+      await createFeedback(payload);
+
+      // 5) 성공 이동
       navigate(ROUTE_PATH.MAIN, { replace: true });
-    } catch (err) {
+    } catch (err: unknown) {
+      // any 금지 → unknown으로 받고 메시지 최소화
+      setErrorMsg('전송 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      // 필요 시 개발모드에서만 상세 로그
       if (import.meta.env.DEV) console.error('[Letter] submit error:', err);
-      setError('전송 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.');
-      alert('전송 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.');
     } finally {
       setSubmitting(false);
     }
@@ -124,11 +115,10 @@ const LetterPage = () => {
               letterTag={formData.letterTag}
               letterText={formData.letterText}
               setFormData={setFormData}
-              // 내부 전송 버튼이 있다면 submitting을 내려서 disabled 처리 가능
-              // disabled={submitting}
             />
           )}
-          {error && <ErrorMsg>{error}</ErrorMsg>}
+
+          {errorMsg && <ErrorText>{errorMsg}</ErrorText>}
         </Form>
       </Main>
       <NavigationCustomer />
@@ -143,14 +133,16 @@ const Main = styled.main`
   min-height: calc(100dvh - ${HEADER_HEIGHT}px - ${NAV_HEIGHT}px);
   background-color: ${({ theme }) => theme.colors.customer.background};
 `;
+
 const Form = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: ${({ theme }) => theme.spacing[4]};
 `;
-const ErrorMsg = styled.p`
+
+const ErrorText = styled.p`
   margin: 0;
-  color: #d00;
+  color: #d32f2f;
   font-size: 13px;
 `;

--- a/src/pages/letter/LetterPage.tsx
+++ b/src/pages/letter/LetterPage.tsx
@@ -7,29 +7,105 @@ import useFile from './hooks/useFile';
 import LetterSendSection from './components/LetterSendSection';
 import { useState, type FormEvent } from 'react';
 import type { LetterTagType } from '@/constants/letter';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { ROUTE_PATH } from '@/routes/paths';
+import {
+  createFeedback,
+  type FeedbackType,
+  type CreateFeedbackRequest,
+} from '@/api/feedback/postFeedback';
 
 const LetterPage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { uploadedFile, isUploaded, handleFileChange } = useFile();
+
   const [formData, setFormData] = useState<{
     satisfaction: number;
-    letterTag: LetterTagType;
+    letterTag: LetterTagType; // 'positive' | 'suggestion' | 'complaint' 라고 가정
     letterText: string;
   }>({
     satisfaction: 0,
-    letterTag: 'positive',
+    letterTag: 'COMPLIMENT',
     letterText: '',
   });
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    // 실제 서버 전송 대신 상태로 확인
-    console.log('폼 데이터:', uploadedFile);
-    console.log('제출됨:', formData);
+  const [, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-    navigate(ROUTE_PATH.MAIN, { replace: true });
+  // StoreDetailPage에서 넘겨준 값 복구 (state 또는 query)
+  const search = new URLSearchParams(location.search);
+  const storeIdFromQuery = search.get('storeId');
+  const receiptIdFromQuery = search.get('receiptId');
+
+  const storeId: number | undefined =
+    (location.state as { storeId?: number } | null)?.storeId ??
+    (storeIdFromQuery ? Number(storeIdFromQuery) : undefined);
+
+  const receiptId: number | undefined =
+    (location.state as { receiptId?: number } | null)?.receiptId ??
+    (receiptIdFromQuery ? Number(receiptIdFromQuery) : undefined);
+
+  const typeMap: Record<LetterTagType, FeedbackType> = {
+    COMPLIMENT: 'COMPLIMENT',
+    SUGGESTION: 'SUGGESTION',
+    COMPLAINT: 'COMPLAINT',
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    // 기본 검증
+    if (!storeId) {
+      setError('가게 정보가 없습니다.');
+      alert('가게 정보가 없습니다.');
+      return;
+    }
+    if (
+      !formData.satisfaction ||
+      formData.satisfaction < 1 ||
+      formData.satisfaction > 5
+    ) {
+      setError('별점을 선택해 주세요.');
+      alert('별점을 선택해 주세요.');
+      return;
+    }
+    if (!formData.letterText.trim()) {
+      setError('내용을 입력해 주세요.');
+      alert('내용을 입력해 주세요.');
+      return;
+    }
+
+    const rid = Number(receiptId);
+    const payload: CreateFeedbackRequest = {
+      storeId, // number
+      receiptId: rid,
+      rating: formData.satisfaction, // number
+      content: formData.letterText.trim(), // string
+      type: typeMap[formData.letterTag], // FeedbackType
+    };
+
+    try {
+      setSubmitting(true);
+
+      if (import.meta.env.DEV) {
+        console.group('[Letter] createFeedback payload');
+        console.log(payload);
+        console.log('uploadedFile (클라이언트만):', uploadedFile);
+        console.groupEnd();
+      }
+
+      const res = await createFeedback(payload);
+      alert(res?.message ?? '피드백이 등록되었습니다.');
+      navigate(ROUTE_PATH.MAIN, { replace: true });
+    } catch (err) {
+      if (import.meta.env.DEV) console.error('[Letter] submit error:', err);
+      setError('전송 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.');
+      alert('전송 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -48,8 +124,11 @@ const LetterPage = () => {
               letterTag={formData.letterTag}
               letterText={formData.letterText}
               setFormData={setFormData}
+              // 내부 전송 버튼이 있다면 submitting을 내려서 disabled 처리 가능
+              // disabled={submitting}
             />
           )}
+          {error && <ErrorMsg>{error}</ErrorMsg>}
         </Form>
       </Main>
       <NavigationCustomer />
@@ -64,10 +143,14 @@ const Main = styled.main`
   min-height: calc(100dvh - ${HEADER_HEIGHT}px - ${NAV_HEIGHT}px);
   background-color: ${({ theme }) => theme.colors.customer.background};
 `;
-
 const Form = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: ${({ theme }) => theme.spacing[4]};
+`;
+const ErrorMsg = styled.p`
+  margin: 0;
+  color: #d00;
+  font-size: 13px;
 `;

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -1,88 +1,163 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 import { ROUTE_PATH } from '@/routes/paths';
-import type { Store } from '@/pages/map/mocks/stores';
-import { mockStores } from '@/pages/map/mocks/stores';
 import BottomSheet from '@/pages/map/components/BottomSheet';
 import SearchTrigger from '@/pages/map/components/SearchTrigger';
 import NavigationCustomer from '@/components/layout/NavigationCustomer';
+import { fetchStoreList, type StoreListItem } from '@/api/store/store';
+import { useAuth } from '@/contexts/AuthContext';
 
-function MapPage() {
+type MarkerLike = { setMap: (m: unknown | null) => void };
+
+export default function MapPage() {
   const mapRef = useRef<HTMLDivElement | null>(null);
-  const [selected, setSelected] = useState<Store | null>(null);
+  const markersRef = useRef<MarkerLike[]>([]);
+  const [selected, setSelected] = useState<StoreListItem | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
   const navigate = useNavigate();
-  const sheetOpen = !!selected;
-
-  const loadScript = (src: string) =>
-    new Promise<void>((resolve, reject) => {
-      const s = document.createElement('script');
-      s.src = src;
-      s.async = true;
-      s.onload = () => resolve();
-      s.onerror = () => reject(new Error(`load failed: ${src}`));
-      document.head.appendChild(s);
-    });
+  const auth = useAuth();
+  const accessToken = auth?.accessToken ?? null; // string | null
 
   useEffect(() => {
+    if (!accessToken) return;
     const KEY = import.meta.env.VITE_KAKAO_MAP_KEY;
-    if (!KEY) return;
+    if (!KEY) {
+      setErr('Kakao API Key가 설정되지 않았습니다.');
+      setLoading(false);
+      return;
+    }
 
-    const markers: kakao.maps.Marker[] = [];
+    let destroyed = false;
 
-    loadScript(
-      `https://dapi.kakao.com/v2/maps/sdk.js?autoload=false&appkey=${KEY}`,
-    )
-      .then(() => {
+    const loadScript = (src: string) =>
+      new Promise<void>((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = src;
+        s.async = true;
+        s.onload = () => resolve();
+        s.onerror = () => reject(new Error(`load failed: ${src}`));
+        document.head.appendChild(s);
+      });
+
+    const init = async () => {
+      try {
+        setLoading(true);
+        await loadScript(
+          `https://dapi.kakao.com/v2/maps/sdk.js?autoload=false&appkey=${KEY}`,
+        );
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const kakao = (window as any).kakao;
+        const kakao = (window as any)?.kakao;
+        if (!kakao?.maps) {
+          setErr('카카오맵 SDK를 불러오지 못했습니다.');
+          setLoading(false);
+          return;
+        }
 
-        kakao.maps.load(() => {
-          if (!mapRef.current) return;
+        kakao.maps.load(async () => {
+          if (destroyed || !mapRef.current) return;
 
-          const center = new kakao.maps.LatLng(35.8889, 128.6109); // 경북대 본관
-          const map = new kakao.maps.Map(mapRef.current, { center, level: 4 });
+          const defaultCenter = new kakao.maps.LatLng(35.8889, 128.6109);
+          const map = new kakao.maps.Map(mapRef.current, {
+            center: defaultCenter,
+            level: 4,
+          });
 
+          // 1) 현재 위치(가능하면)
+          let lat = 35.8889;
+          let lng = 128.6109;
           if (navigator.geolocation) {
-            navigator.geolocation.getCurrentPosition(
-              (pos) => {
-                const cur = new kakao.maps.LatLng(
-                  pos.coords.latitude,
-                  pos.coords.longitude,
-                );
-                map.setCenter(cur);
-                const me = new kakao.maps.Marker({ map, position: cur });
-                markers.push(me);
-              },
-              () => {},
-            );
+            try {
+              const pos = await new Promise<GeolocationPosition>((res, rej) =>
+                navigator.geolocation.getCurrentPosition(res, rej, {
+                  enableHighAccuracy: true,
+                  maximumAge: 10_000,
+                }),
+              );
+              lat = pos.coords.latitude;
+              lng = pos.coords.longitude;
+
+              const cur = new kakao.maps.LatLng(lat, lng);
+              map.setCenter(cur);
+              const me = new kakao.maps.Marker({ map, position: cur });
+              markersRef.current.push(me);
+            } catch (geoErr) {
+              if (import.meta.env.DEV) {
+                console.debug('[MapPage] geolocation error:', geoErr);
+              }
+            }
           }
 
-          const storeMarkers = mockStores.map((s) => {
-            const m = new kakao.maps.Marker({
+          if (!accessToken) {
+            setErr('로그인 후 이용해주세요.');
+            setLoading(false);
+            return;
+          }
+
+          // 3) 가게 리스트 호출 (헤더에 토큰 포함)
+          let stores: StoreListItem[] = [];
+          try {
+            if (import.meta.env.DEV) {
+              console.log(
+                '[MapPage] calling /api/store/list with header.Authorization',
+              );
+            }
+            stores = await fetchStoreList(
+              { latitude: lat, longitude: lng },
+              accessToken,
+            );
+
+            // dev 확인용
+
+            if (import.meta.env.DEV) {
+              console.group('[MapPage] /store/list result');
+              console.log('count:', stores.length);
+              console.log('first:', stores[0]);
+              console.groupEnd();
+            }
+          } catch (apiErr: unknown) {
+            if (import.meta.env.DEV)
+              console.error('[MapPage] fetchStoreList error:', apiErr);
+            setErr('가게 목록을 불러오지 못했습니다. (권한/네트워크 확인)');
+            setLoading(false);
+            return;
+          }
+
+          // 4) 마커 렌더링
+          stores.forEach((s) => {
+            const marker = new kakao.maps.Marker({
               map,
-              position: new kakao.maps.LatLng(s.lat, s.lng),
+              position: new kakao.maps.LatLng(s.latitude, s.longitude),
             });
-            kakao.maps.event.addListener(m, 'click', () => {
-              console.log('[marker click]', s.name);
-              setSelected(s);
-            });
-            return m;
+            kakao.maps.event.addListener(marker, 'click', () => setSelected(s));
+            markersRef.current.push(marker);
           });
-          markers.push(...storeMarkers);
+
+          setLoading(false);
         });
-      })
-      .catch(console.error);
+      } catch (e) {
+        if (import.meta.env.DEV) console.error('[MapPage] init error:', e);
+        setErr('지도를 초기화하지 못했습니다.');
+        setLoading(false);
+      }
+    };
+
+    init();
 
     return () => {
+      destroyed = true;
       try {
-        markers.forEach((m) => m.setMap(null));
-      } catch {
-        // intentionally ignored
+        markersRef.current.forEach((m) => m.setMap?.(null));
+      } catch (cleanupErr) {
+        if (import.meta.env.DEV)
+          console.debug('[MapPage] cleanup error:', cleanupErr);
       }
+      markersRef.current = [];
       setSelected(null);
     };
-  }, []);
+  }, [accessToken]);
 
   return (
     <Wrap>
@@ -91,25 +166,27 @@ function MapPage() {
         <SearchTrigger onClick={() => navigate(ROUTE_PATH.SEARCH)} />
       </TopBar>
 
-      <SheetWrap open={sheetOpen}>
+      {loading && <Toast>지도를 불러오는 중…</Toast>}
+      {err && <Toast>{err}</Toast>}
+
+      <SheetWrap open={!!selected}>
         <BottomSheet
-          open={sheetOpen}
+          open={!!selected}
           title={selected?.name}
           subtitle={selected?.category}
-          //imageUrl={selected?.imageUrl}
+          imageUrl={selected?.imageUrl}
           onClose={() => setSelected(null)}
         />
       </SheetWrap>
 
-      <NavHolder hidden={sheetOpen}>
+      <NavHolder hidden={!!selected}>
         <NavigationCustomer />
       </NavHolder>
     </Wrap>
   );
 }
 
-export default MapPage;
-
+/* --- styles --- */
 const Wrap = styled.div`
   position: relative;
   width: 100%;
@@ -117,30 +194,23 @@ const Wrap = styled.div`
   max-width: 720px;
   margin: 0 auto;
 `;
-
 const MapBox = styled.div`
   position: absolute;
   inset: 0;
   z-index: 1;
 `;
-
 const TopBar = styled.div`
   position: absolute;
   z-index: 4;
   top: 12px;
   left: 50%;
   transform: translateX(-50%);
-
-  /* 화면 좌우 여백 12px 유지하면서 720px 이하로 */
   width: min(720px, calc(100% - 24px));
-
-  /* 지도 클릭 살리기: 컨테이너는 무시, 자식만 클릭 */
   pointer-events: none;
   & > * {
     pointer-events: auto;
   }
 `;
-
 const SheetWrap = styled.div<{ open: boolean }>`
   position: absolute;
   z-index: 8;
@@ -149,7 +219,6 @@ const SheetWrap = styled.div<{ open: boolean }>`
   bottom: 0;
   pointer-events: ${({ open }) => (open ? 'auto' : 'none')};
 `;
-
 const NavHolder = styled.div<{ hidden: boolean }>`
   position: absolute;
   z-index: 6;
@@ -157,11 +226,21 @@ const NavHolder = styled.div<{ hidden: boolean }>`
   right: 0;
   bottom: 0;
   padding-bottom: env(safe-area-inset-bottom, 0px);
-  pointer-events: auto;
-
   transform: translateY(${({ hidden }) => (hidden ? '110%' : '0%')});
   opacity: ${({ hidden }) => (hidden ? 0 : 1)};
   transition:
     transform 0.28s ease,
     opacity 0.2s ease;
+`;
+const Toast = styled.div`
+  position: absolute;
+  z-index: 7;
+  left: 50%;
+  top: 64px;
+  transform: translateX(-50%);
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: rgba(17, 17, 17, 0.8);
+  color: #fff;
+  font-size: 12px;
 `;

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -69,14 +69,11 @@ export default function SearchPage() {
         onSubmit={() => submit()}
         onBack={() => navigate(-1)}
       />
-
       {loading && <Empty>검색 중…</Empty>}
       {!loading && error && <Empty>{error}</Empty>}
-
       {!loading && !error && keyword.trim().length === 0 && (
         <SearchEmpty message='검색어를 입력해보세요.' navHeight={NAV_HEIGHT} />
       )}
-
       {!loading &&
         !error &&
         keyword.trim().length > 0 &&
@@ -86,11 +83,21 @@ export default function SearchPage() {
             navHeight={NAV_HEIGHT}
           />
         )}
-
       {!loading && !error && items.length > 0 && (
         <SearchResults
           results={items.map((s) => ({
-            store: { ...s, id: Number(s.id) },
+            store: {
+              id: Number(s.id),
+              name: s.name,
+              canonicalName: s.canonicalName,
+              address: s.address,
+              lat: s.latitude,
+              lng: s.longitude,
+              description: s.description,
+              category: s.category,
+              imageUrl: s.imageUrl,
+              openingTime: s.openingTime,
+            },
             distanceM: null,
           }))}
           onSelect={(s) => goDetail(s.id)}

--- a/src/pages/search/apis/search.ts
+++ b/src/pages/search/apis/search.ts
@@ -1,55 +1,53 @@
-import { mockStores } from '@/pages/map/mocks/stores';
-import { delay } from '@/mocks/utils';
+import { fetchStoreList, type StoreListItem } from '@/api/store/store';
 
-export type SearchItem = {
-  id: string;
-  name: string;
-  lat: number;
-  lng: number;
-  category?: string;
-  image?: string;
-  address?: string;
-  openTime?: string;
-  closeTime?: string;
-};
+// SearchResults에서 기대하는 아이템 구조 = 백엔드 리스트 아이템과 동일
+export type SearchItem = StoreListItem;
 
-// 백엔드 API와 연동하는 경우 추가?
+// 경북대학교(기본 좌표, 위치 권한 거부/실패 시 사용)
+const DEFAULT_LAT = 35.8889;
+const DEFAULT_LNG = 128.6109;
 
-// export async function searchStores(
-//   keyword: string,
-//   opts?: { signal?: AbortSignal },
-// ): Promise<SearchItem[]> {
-//   const q = keyword.trim();
-//   if (!q) return [];
-//   const res = await fetch(
-//     `/api/stores/search?keyword=${encodeURIComponent(q)}`, //예시
-//     {
-//       signal: opts?.signal,
-//     },
-//   );
-//   if (!res.ok) throw new Error(`Search failed: ${res.status}`);
-//   const data = await res.json();
-//   // 백엔드 응답 구조에 맞게 매핑
-//   return Array.isArray(data.items) ? data.items : data;
-// }
-
-function filterMock(keyword: string): SearchItem[] {
-  const q = keyword.trim().toLowerCase();
-  if (!q) return [];
-  return mockStores
-    .filter((s) => {
-      const inName = s.name.toLowerCase().includes(q);
-      const inCat = s.category ? s.category.toLowerCase().includes(q) : false;
-      const inAddr = s.address ? s.address.toLowerCase().includes(q) : false;
-      return inName || inCat || inAddr;
-    })
-    .map((s) => ({ ...s, id: String(s.id) }));
+async function getCoords(): Promise<{ lat: number; lng: number }> {
+  // 브라우저 현재 위치 → 실패하면 KNU 좌표로 fallback
+  return await new Promise((resolve) => {
+    if (!navigator.geolocation) {
+      resolve({ lat: DEFAULT_LAT, lng: DEFAULT_LNG });
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) =>
+        resolve({
+          lat: pos.coords.latitude,
+          lng: pos.coords.longitude,
+        }),
+      () => resolve({ lat: DEFAULT_LAT, lng: DEFAULT_LNG }),
+      { enableHighAccuracy: true, maximumAge: 10_000, timeout: 5000 },
+    );
+  });
 }
 
-export async function searchStores(
-  keyword: string,
-  { delayMs = 200 }: { delayMs?: number } = {},
-): Promise<SearchItem[]> {
-  await delay(delayMs);
-  return filterMock(keyword);
+// 검색 API
+// - keyword와 현재 좌표를 백엔드에 전달
+// - 토큰은 axios 인터셉터에서 자동으로 Authorization 주입됨
+
+export async function searchStores(keyword: string): Promise<SearchItem[]> {
+  const q = keyword.trim();
+  if (!q) return [];
+
+  const { lat, lng } = await getCoords();
+
+  const list = await fetchStoreList({
+    keyword: q,
+    latitude: lat,
+    longitude: lng,
+  });
+
+  if (import.meta.env.DEV) {
+    console.group('[searchStores] /api/store/list');
+    console.log('keyword:', q, 'lat/lng:', lat, lng);
+    console.log('count:', list.length, 'first:', list[0]);
+    console.groupEnd();
+  }
+
+  return list;
 }

--- a/src/pages/store/types.ts
+++ b/src/pages/store/types.ts
@@ -21,6 +21,7 @@ export interface StoreAnnouncementDTO {
   feedbackId: number;
   feedbackContent: string;
   content: string;
+  description?: string;
 }
 
 export interface StoreDetailDTO {
@@ -35,6 +36,6 @@ export interface StoreDetailDTO {
   category?: Category;
   imageUrl?: string;
   openingTime?: string;
-  menus: MenuDTO[];
-  storeAnnouncements: StoreAnnouncementDTO[];
+  menuList: MenuDTO[];
+  announcementList: StoreAnnouncementDTO[];
 }

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -20,8 +20,8 @@ import MyLetterPage from '@/pages/my/customer/letter/MyLetterPage';
 import FeedbackPage from '@/pages/feedback/FeedbackPage';
 import CompletedTab from '@/pages/feedback/components/CompletedTab';
 import AllTab from '@/pages/feedback/components/AllTab';
-import PendingTab from '@/pages/feedback/components/PendingTab';
 import SignUpPage from '@/pages/auth/SignUpPage';
+import UnReadTab from '@/pages/feedback/components/unReadTab';
 
 const Router = () => {
   return (
@@ -55,7 +55,7 @@ const Router = () => {
           path={ROUTE_PATH.FEEDBACK_COMPLETED}
           element={<CompletedTab />}
         />
-        <Route path={ROUTE_PATH.FEEDBACK_PENDING} element={<PendingTab />} />
+        <Route path={ROUTE_PATH.FEEDBACK_PENDING} element={<UnReadTab />} />
       </Route>
       <Route path={ROUTE_PATH.INTERACTION} element={<InteractionPage />} />
     </Routes>

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -21,7 +21,7 @@ import FeedbackPage from '@/pages/feedback/FeedbackPage';
 import CompletedTab from '@/pages/feedback/components/CompletedTab';
 import AllTab from '@/pages/feedback/components/AllTab';
 import SignUpPage from '@/pages/auth/SignUpPage';
-import UnReadTab from '@/pages/feedback/components/unReadTab';
+import UnReadTab from '@/pages/feedback/components/UnReadTab';
 
 const Router = () => {
   return (

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -35,12 +35,12 @@ export const theme = {
     },
     tag: {
       star: '#f1f436',
-      positive: '#e5ffd4',
-      improve: '#dbe9fe',
-      complain: '#ffdcda',
+      COMPLIMENT: '#e5ffd4',
+      SUGGESTION: '#dbe9fe',
+      COMPLAINT: '#ffdcda',
     },
     feedback: {
-      PROCESSING: '#FFF7ED',
+      UNREAD: '#FFF7ED',
       DONE: '#EEF7FF',
     },
     // 텍스트 색상

--- a/src/types/feedback.d.ts
+++ b/src/types/feedback.d.ts
@@ -1,0 +1,9 @@
+type Feedback = {
+  id: number;
+  rating: number;
+  modifiedContent: string;
+  reply: string | null;
+  type: 'COMPLAINT' | 'SUGGESTION' | 'COMPLIMENT';
+  status: 'UNREAD' | 'DONE';
+  createdAt: string;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import path from 'path';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 8080, // 포트 5178로 변경 -> 임시로 서버 연결위해 사용
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## ✨ 요약

> PR의 목적을 한두 문장으로 요약합니다.

지도에서 매장 리스트/상세를 백엔드와 연동하고, 영수증 OCR → 피드백 생성까지의 사용자 플로우를 완성했습니다. (토큰은 axios 인터셉터로 자동 주입)

## 🔗 작업 내용

- 지도(MapPage)에서 백엔드 /api/store/list 호출 → 마커 표시, bounds 맞춤
- 검색(SearchPage)에서 키워드+좌표 기반 /api/store/list 연동
- 상세(StoreDetailPage)에서 /api/store/{id} 연동 및 UI 유지, 거리 계산 표시
- 이미지 URL 교정(예: https://example.com/... → 서버 오리진 + /store|/menu/...)
- 영수증 OCR 업로드(/api/receipt/ocr) → receiptId로 피드백 생성(/api/feedbacks)
- axios 인터셉터에서 Authorization: Bearer <token> 자동 주입, 응답 data 언랩

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

- axiosInstance
   - baseURL = VITE_BASE_API_URL
   - 요청 인터셉터: sessionStorage.getItem(SESSION_AUTH_KEY)로 토큰 읽어 Authorization 설정
   - 응답 인터셉터: response.data?.data ?? response.data로 언랩

- Store API (src/api/store/store.ts)
   - fetchStoreList(params) / fetchStoreDetail(id) 타입 안전하게 정의
   - buildAssetUrl(kind, url)로 이미지 절대경로 강제:
   - 오리진: VITE_ASSET_BASE_URL || VITE_BASE_API_URL
   - example.com/images/... 등 이전 포맷을 /store/파일 또는 /menu/파일로 교정
   - 상세 응답 필드명 백엔드에 맞춤: menuList, announcementList

- MapPage
   - 카카오맵 SDK 로드 후 리스트 호출 → 마커 렌더, LatLngBounds로 화면 맞춤
   - 현재 위치 마커는 보조(실패해도 기본 좌표 유지)
   - 정리 시 마커 제거 및 에러 로깅(빈 catch {} 제거)

- SearchPage
   - searchStores(keyword, { lat, lng }) 호출 시 URL에 keyword 반영
   - 결과를 SearchResults가 요구하는 타입으로 매핑(lat/lng vs latitude/longitude 이슈 해결)

- StoreDetailPage
   - 기존 UI 그대로 유지 (헤더, 카테고리, 히어로, 버튼, 섹션 등)
   - 거리 계산(현재 위치 ↔︎ 매장 좌표) 추가
   - menuList, announcementList 안전 가드 후 렌더
   - 이미지 경로 교정 반영

- 영수증 & 피드백
   - uploadReceiptOcr(file: File) → POST /api/receipt/ocr (multipart/form-data) → { id: receiptId, ... }
   - createFeedback({ storeId, receiptId, rating, content, type }) → POST /api/feedbacks
   - LetterPage 제출 플로우:
 
	1. 유효성 검사(storeId, 파일, 내용)
	2. OCR 업로드로 receiptId 발급
	3. receiptId 포함하여 피드백 생성
	4. 성공 시 메인으로 이동
	- any 미사용, unknown + 최소 가드로 에러 처리


## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

- 알려진 이슈
    - 백엔드가 imageUrl을 example.com/...로 내려보내는 경우에도 교정기로 서버 오리진 + /store|/menu에 매핑하지만, 파일명이 일치해야 정상 노출됩니다(파일명 불일치 시 404).

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #36 
