### PR TITLE
feat: BottomSheet 에서 클릭시 이동 콜백 추가 (상세 페이지 연결)

### DIFF
--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
-import { useNavigate } from 'react-router-dom';
+import { generatePath, useNavigate } from 'react-router-dom';
 import { ROUTE_PATH } from '@/routes/paths';
 import BottomSheet from '@/pages/map/components/BottomSheet';
 import SearchTrigger from '@/pages/map/components/SearchTrigger';
@@ -165,6 +165,13 @@ export default function MapPage() {
           subtitle={selected?.category}
           imageUrl={selected?.imageUrl}
           onClose={() => setSelected(null)}
+          onClickDetail={() => {
+            if (!selected) return;
+            const path = generatePath(ROUTE_PATH.STORE_DETAIL, {
+              id: String(selected.id),
+            });
+            navigate(path);
+          }}
         />
       </SheetWrap>
 

--- a/src/pages/map/components/BottomSheet.tsx
+++ b/src/pages/map/components/BottomSheet.tsx
@@ -6,6 +6,7 @@ type Props = {
   subtitle?: string;
   imageUrl?: string;
   onClose: () => void;
+  onClickDetail?: () => void;
 };
 
 export default function BottomSheet({
@@ -14,6 +15,7 @@ export default function BottomSheet({
   subtitle,
   imageUrl,
   onClose,
+  onClickDetail,
 }: Props) {
   return (
     <Dim open={open} onClick={onClose} aria-hidden={!open}>
@@ -23,7 +25,12 @@ export default function BottomSheet({
         aria-modal='true'
         aria-labelledby='bs-title'
         aria-describedby='bs-subtitle'
-        onClick={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClickDetail?.();
+        }}
+        tabIndex={0}
+        aria-label='가게 상세로 이동'
       >
         <Grab />
         <Header>
@@ -64,6 +71,7 @@ const Panel = styled.div<OpenProp>`
   box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.08);
   transform: translateY(${({ open }) => (open ? '0' : '8px')});
   transition: transform 0.24s ease;
+  cursor: pointer;
 `;
 
 const Grab = styled.div`


### PR DESCRIPTION
## ✨ 요약

> PR의 목적을 한두 문장으로 요약합니다.

바텀 시트(매장 미리보기)를 탭하면 해당 매장 상세 페이지로 바로 이동하도록 클릭 콜백을 추가했습니다. 사용 흐름이 “마커 클릭 → 시트 탭 → 상세”로 매끄럽게 이어집니다.

## 🔗 작업 내용

- BottomSheet 컴포넌트에 선택적 콜백 onClickDetail prop 추가
- 시트 패널 클릭 시 이벤트 버블링 차단 후 onClickDetail 호출
- 접근성 보강: 패널에 role="button", tabIndex={0}, aria-label 부여, 포인터 커서 적용
- MapPage에서 onClickDetail에 라우팅 연결 (navigate(generatePath(ROUTE_PATH.STORE_DETAIL, { id })))
- Dim(배경) 클릭 시 기존대로 시트 닫힘 유지 (동작 변경 없음)

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

- BottomSheet.tsx
   - 새 prop: onClickDetail?: () => void
   - 패널(Panel) 클릭 시 e.stopPropagation() 후 onClickDetail?.() 실행
   - 키보드/스크린리더 대응을 위해 role="button", tabIndex={0}, aria-label 추가
   - 스타일에 cursor: pointer 추가(인터랙션 힌트)

- MapPage.tsx
   - BottomSheet 사용부에 onClickDetail 전달
   - 선택된 매장이 있을 때만 navigate 수행, 없으면 무시(안전 가드)
   - 라우트는 ROUTE_PATH.STORE_DETAIL + generatePath로 구성

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #52 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * From the map view, tap the bottom sheet to open the store detail page.
* **Accessibility**
  * Bottom sheet is now keyboard-focusable and includes an accessible label for screen readers.
* **UX**
  * Clicking inside the bottom sheet triggers the detail view without closing the sheet.
  * Cursor now indicates interactivity on the bottom sheet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->